### PR TITLE
[Feat] BE 타입 검사 추가

### DIFF
--- a/BE/Makefile
+++ b/BE/Makefile
@@ -1,7 +1,8 @@
-
 all:
 	@make format
 	@make lint
+	@make type
+	@make test
 
 format:
 	@echo "Formatting code with black"
@@ -11,4 +12,12 @@ lint:
 	@echo "Linting code with pylint"
 	@venv/bin/pylint backend
 
-.PHONY: all format lint
+type:
+	@echo "Typechecking with mypy"
+	@venv/bin/mypy backend --ignore-missing-imports
+
+test:
+	@echo "Running Django unit tests"
+	@venv/bin/python manage.py test
+
+.PHONY: all format lint typecheck test

--- a/BE/backend/settings.py
+++ b/BE/backend/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 
 import os
 from pathlib import Path
+from typing import List
 
 import environ
 
@@ -33,7 +34,7 @@ SECRET_KEY = env("SECRET_KEY")
 # False if not in os.environ because of casting above
 DEBUG = env("DEBUG")
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS: List[str] = []
 
 
 # Application definition

--- a/BE/requirements.txt
+++ b/BE/requirements.txt
@@ -7,6 +7,7 @@ Django==5.0.2
 django-environ==0.11.2
 isort==5.13.2
 mccabe==0.7.0
+mypy==1.8.0
 mypy-extensions==1.0.0
 packaging==23.2
 pathspec==0.12.1
@@ -16,3 +17,4 @@ pylint-django==2.5.5
 pylint-plugin-utils==0.8.2
 sqlparse==0.4.4
 tomlkit==0.12.4
+typing_extensions==4.10.0

--- a/GAME/Makefile
+++ b/GAME/Makefile
@@ -1,7 +1,8 @@
-
 all:
 	@make format
 	@make lint
+	@make type
+	@make test
 
 format:
 	@echo "Formatting code with black"
@@ -11,4 +12,12 @@ lint:
 	@echo "Linting code with pylint"
 	@venv/bin/pylint game_server
 
-.PHONY: all format lint
+type:
+	@echo "Typechecking with mypy"
+	@venv/bin/mypy game_server --ignore-missing-imports
+
+test:
+	@echo "Running Django unit tests"
+	@venv/bin/python manage.py test
+
+.PHONY: all format lint typecheck test

--- a/GAME/game_server/settings.py
+++ b/GAME/game_server/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 
 import os
 from pathlib import Path
+from typing import List
 
 import environ
 
@@ -31,9 +32,10 @@ environ.Env.read_env(os.path.join(BASE_DIR, ".env"))
 SECRET_KEY = env("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+# False if not in os.environ because of casting above
+DEBUG = env("DEBUG")
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS: List[str] = []
 
 
 # Application definition

--- a/GAME/requirements.txt
+++ b/GAME/requirements.txt
@@ -7,6 +7,7 @@ Django==5.0.2
 django-environ==0.11.2
 isort==5.13.2
 mccabe==0.7.0
+mypy==1.8.0
 mypy-extensions==1.0.0
 packaging==23.2
 pathspec==0.12.1
@@ -16,3 +17,4 @@ pylint-django==2.5.5
 pylint-plugin-utils==0.8.2
 sqlparse==0.4.4
 tomlkit==0.12.4
+typing_extensions==4.10.0


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

- python 내 타입 검사를 위해 mypy를 추가로 도입 및 Makefile 수정

## 🧑‍💻 PR 세부 내용

- mypy 추가

- Makefile에 타입 검사, 유닛 테스트 명령어 추가
  - `make type`: mypy를 이용한 타입 검사 수행
  - `make test`: django 내장 테스트 프레임워크를 이용한 테스트 수행

- GAME 프로젝트의 settings.py에 DEBUG 환경 변수가 누락되어 있던 부분 수정

## 📸 스크린샷

<img width="572" alt="Screen Shot 2024-03-03 at 9 44 52 PM" src="https://github.com/authenticity-house/ft_transcendence/assets/43935708/bbb8ca70-196d-4287-ab45-3c2f98b339f7">

## 📚 관련 이슈

- close: #6
