### PR TITLE
[Feat] 게임 서버-클라이언트 로컬 1대1 웹소켓 규약 적용

### DIFF
--- a/GAME/websocket/consumers.py
+++ b/GAME/websocket/consumers.py
@@ -19,15 +19,66 @@ class GameConsumer(AsyncWebsocketConsumer):
             )
         )
 
-        self.match_manager = MatchManager(self)
-        self.game_session = asyncio.create_task(self.match_manager.start_game())
-
     async def receive(self, text_data=None, bytes_data=None):
         msg = json.loads(text_data)
-        msg_type, msg_subtype, msg_data = msg["type"], msg["subtype"], msg["data"]
-        if msg_type == "game" and msg_subtype == "key_down":
-            key_set: set = set(msg_data["key_set"])
-            self.match_manager.keys = key_set
+        msg_type, msg_subtype, msg_data = msg["type"], msg["subtype"], msg["data"] # Todo: json에 해당 헤더가 없는 경우 예외 발생
+        if msg_type == "game":
+            if msg_subtype == "key_down":
+                key_set = msg_data["key_set"]
+                self.match_manager.keys = key_set
+            elif msg_subtype == "session_info": # 게임 초기 정보
+                print(msg_data["battle_mode"])
+                print(msg_data["total_score"])
+                print(msg_data["battle_mode"])
+                print(msg_data["level"])
+                print(msg_data["color"]["paddle"])
+                print(msg_data["color"]["background"])
+
+                self.match_manager = MatchManager(self)
+                self.game_session = asyncio.create_task(self.match_manager.start_game())
+
+                # await self.send(
+                #     text_data=json.dumps(
+                #         {
+                #             "type": "game",
+                #             "subtype": "match_init_setting",
+                #             "message": "",
+                #             "match_id": 123,
+                #             "data": {
+                #                 "battle_mode": 1,
+                #                 "color": {
+                #                     "paddle": "#FFFFFF",
+                #                     "background": "#FFFFFF",
+                #                     "ball": "#FFFFFF",
+                #                 },
+                #                 "ball": {
+                #                     "status": "in",
+                #                     "x": 0.0,
+                #                     "y": 0.0,
+                #                     "radius": 0.04,
+                #                 },
+                #                 "paddle1": {
+                #                     "x": -2.8,
+                #                     "y": 0.0,
+                #                     "width": 0.1,
+                #                     "height": 0.5,
+                #                 },
+                #                 "paddle2": {
+                #                     "x": 2.8,
+                #                     "y": 0.0,
+                #                     "width": 0.1,
+                #                     "height": 0.5,
+                #                 },
+                #                 "nickname": {
+                #                     "player1": "wonyang",
+                #                     "player2": "jeongmin"
+                #                 }
+                #             },
+                #         }
+                #     )
+                # )
+
+                pass
 
     async def disconnect(self, code):
         # code: 1000 정상 종료 1001 상대방이 떠남 1002 프로토콜 오류 (로깅 시 사용)

--- a/GAME/websocket/consumers.py
+++ b/GAME/websocket/consumers.py
@@ -8,6 +8,7 @@ class GameConsumer(AsyncWebsocketConsumer):
     def __init__(self, *args, **kwargs):
         super().__init__(args, kwargs)
         self.match_manager = None
+        self.game_session = None
 
     async def connect(self):
         await self.accept()
@@ -19,9 +20,19 @@ class GameConsumer(AsyncWebsocketConsumer):
         )
 
         self.match_manager = MatchManager(self)
-        asyncio.create_task(self.match_manager.start_game())
+        self.game_session = asyncio.create_task(self.match_manager.start_game())
 
     async def receive(self, text_data=None, bytes_data=None):
         text_data_json = json.loads(text_data)
         key_set = text_data_json["key_set"]
         await self.match_manager.local_move_paddles(key_set)
+
+    async def disconnect(self, code):
+        # code: 1000 정상 종료 1001 상대방이 떠남 1002 프로토콜 오류 (로깅 시 사용)
+        if self.game_session:
+            self.game_session.cancel()
+            try:
+                await self.game_session
+            except asyncio.CancelledError:
+                # 게임 세션 취소 성공
+                pass

--- a/GAME/websocket/consumers.py
+++ b/GAME/websocket/consumers.py
@@ -34,13 +34,15 @@ class GameConsumer(AsyncWebsocketConsumer):
                 key_set = msg_data["key_set"]
                 self.match_manager.keys = set(key_set)
 
-            elif msg_subtype == "session_info": # 게임 초기 정보
-                print(msg_data["battle_mode"])
-                print(msg_data["total_score"])
-                print(msg_data["battle_mode"])
-                print(msg_data["level"])
-                print(msg_data["color"]["paddle"])
-                print(msg_data["color"]["background"])
+            elif msg_subtype == "session_info":  # 게임 초기 정보
+                self.match_manager = MatchManager(socket=self, total_score=msg_data["total_score"])
+
+                # print(msg_data["battle_mode"]) -> 토너먼트 미구현
+                # 로컬이라 플레이어 이름 정보 저장 미구현
+                # 레벨, 패들색, 배경색 정보 저장 미구현
+                # print(msg_data["level"])
+                # print(msg_data["color"]["paddle"])
+                # print(msg_data["color"]["background"])
 
                 await self.send(
                     text_data=json.dumps(
@@ -75,15 +77,14 @@ class GameConsumer(AsyncWebsocketConsumer):
                                     "height": 0.5,
                                 },
                                 "nickname": {
-                                    "player1": "wonyang",
-                                    "player2": "jeongmin"
-                                }
+                                    "player1": self.match_manager.player1.name,
+                                    "player2": self.match_manager.player2.name,
+                                },
                             },
                         }
                     )
                 )
             elif msg_subtype == "match_start":
-                self.match_manager = MatchManager(self)
                 self.game_session = asyncio.create_task(self.match_manager.start_game())
 
     async def disconnect(self, code):

--- a/GAME/websocket/consumers.py
+++ b/GAME/websocket/consumers.py
@@ -21,11 +21,19 @@ class GameConsumer(AsyncWebsocketConsumer):
 
     async def receive(self, text_data=None, bytes_data=None):
         msg = json.loads(text_data)
-        msg_type, msg_subtype, msg_data = msg["type"], msg["subtype"], msg["data"] # Todo: json에 해당 헤더가 없는 경우 예외 발생
+        msg_type = msg["type"]
+
+        if msg_type == "disconnect":
+            print("client: disconnect plz")
+            await self.close(code=1000)
+
         if msg_type == "game":
+            msg_subtype, msg_data = msg["subtype"], msg["data"]
+
             if msg_subtype == "key_down":
                 key_set = msg_data["key_set"]
-                self.match_manager.keys = key_set
+                self.match_manager.keys = set(key_set)
+
             elif msg_subtype == "session_info": # 게임 초기 정보
                 print(msg_data["battle_mode"])
                 print(msg_data["total_score"])
@@ -34,51 +42,49 @@ class GameConsumer(AsyncWebsocketConsumer):
                 print(msg_data["color"]["paddle"])
                 print(msg_data["color"]["background"])
 
+                await self.send(
+                    text_data=json.dumps(
+                        {
+                            "type": "game",
+                            "subtype": "match_init_setting",
+                            "message": "",
+                            "match_id": 123,
+                            "data": {
+                                "battle_mode": 1,
+                                "color": {
+                                    "paddle": "#FFFFFF",
+                                    "background": "#FFFFFF",
+                                    "ball": "#FFFFFF",
+                                },
+                                "ball": {
+                                    "status": "in",
+                                    "x": 0.0,
+                                    "y": 0.0,
+                                    "radius": 0.04,
+                                },
+                                "paddle1": {
+                                    "x": -2.8,
+                                    "y": 0.0,
+                                    "width": 0.1,
+                                    "height": 0.5,
+                                },
+                                "paddle2": {
+                                    "x": 2.8,
+                                    "y": 0.0,
+                                    "width": 0.1,
+                                    "height": 0.5,
+                                },
+                                "nickname": {
+                                    "player1": "wonyang",
+                                    "player2": "jeongmin"
+                                }
+                            },
+                        }
+                    )
+                )
+            elif msg_subtype == "match_start":
                 self.match_manager = MatchManager(self)
                 self.game_session = asyncio.create_task(self.match_manager.start_game())
-
-                # await self.send(
-                #     text_data=json.dumps(
-                #         {
-                #             "type": "game",
-                #             "subtype": "match_init_setting",
-                #             "message": "",
-                #             "match_id": 123,
-                #             "data": {
-                #                 "battle_mode": 1,
-                #                 "color": {
-                #                     "paddle": "#FFFFFF",
-                #                     "background": "#FFFFFF",
-                #                     "ball": "#FFFFFF",
-                #                 },
-                #                 "ball": {
-                #                     "status": "in",
-                #                     "x": 0.0,
-                #                     "y": 0.0,
-                #                     "radius": 0.04,
-                #                 },
-                #                 "paddle1": {
-                #                     "x": -2.8,
-                #                     "y": 0.0,
-                #                     "width": 0.1,
-                #                     "height": 0.5,
-                #                 },
-                #                 "paddle2": {
-                #                     "x": 2.8,
-                #                     "y": 0.0,
-                #                     "width": 0.1,
-                #                     "height": 0.5,
-                #                 },
-                #                 "nickname": {
-                #                     "player1": "wonyang",
-                #                     "player2": "jeongmin"
-                #                 }
-                #             },
-                #         }
-                #     )
-                # )
-
-                pass
 
     async def disconnect(self, code):
         # code: 1000 정상 종료 1001 상대방이 떠남 1002 프로토콜 오류 (로깅 시 사용)


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

게임 서버와 클라이언트에 로컬 1대1 웹소켓 규약을 적용

## 🧑‍💻 PR 세부 내용

### 웹소켓 종료 로직 구현

- 게임이 시작되면 task 등록 후 game_session에 저장
- 연결이 종료되어 disconnect 함수 호출 시 game_session을 종료

### 로컬 1대1 규약 적용

- 서로 통신 규약을 올바르게 지켰을 때만 고려

### 클라이언트의 총점 정보 적용

- 클라이언트가 보낸 총점 정보를 MatchManager에 적용
```python
self.match_manager = MatchManager(socket=self, total_score=msg_data["total_score"])
```

- 이외의 게임 초기화 부분은 미구현되어 주석 처리

### 클라이언트 웹소켓 부분 구현

- 수신 받은 메시지별로 행동해야할 구역 구분

```javascript
async function receiveMessages() {
  websocket.onmessage = (event) => {
    const message = JSON.parse(event.data);
  
    switch(message.type) {
      // 1-2. 커넥션 연결 성공 메시지 전송
      case "connection_established":

        // 2-1. 게임 서버로 게임 초기 정보 전송
        sendGameSessionInfo();
        break;

      case "game":
        // 2-2. 클라이언트로 게임 초기 정보 전송
        if(message.subtype === "match_init_setting") {
          // 게임 시작 준비 완료 후 시작 요청 메시지 전송
          sendGameStartRequest();

        // 3-2. 클라이언트로 게임 매치 데이터 전송
        } else if (message.subtype === "match_run") {
          renderThreeJs(message.data);

        // 4-1. 클라이언트로 매치 통계 정보 전송
        } else if (message.subtype === "match_end") {
          console.log("game end!");

          // 4-2. 게임 서버로 연결 종료 요청 전송
          const message = {
            "type": "disconnect",
            "message": "plz!"
          }
          websocket.send(JSON.stringify(message));
        }
        break;
```

## 📸 스크린샷

<img width="324" alt="image" src="https://github.com/authenticity-house/ft_transcendence/assets/43935708/cad653b9-bc5c-4d8b-a247-0b6cf62e2be1">

<img width="523" alt="image" src="https://github.com/authenticity-house/ft_transcendence/assets/43935708/22696772-8694-4199-9ebd-e93bc219c915">


## 📚 관련 이슈

- close: #24 