### PR TITLE
[Refactor] 게임 서버 웹 소켓

### DIFF
--- a/FE/src/pages/GamePage.js
+++ b/FE/src/pages/GamePage.js
@@ -405,12 +405,14 @@ class GamePage {
 			websocket.onmessage = (event) => {
 				const message = JSON.parse(event.data);
 				switch (message.type) {
-					case 'connection_established':
-						sendGameSessionInfo();
-						break;
+					// case 'connection_established':
+					// 	sendGameSessionInfo();
+					// 	break;
 
 					case 'game':
-						if (message.subtype === 'match_init_setting') {
+						if (message.subtype === 'connection_established') {
+							sendGameSessionInfo();
+						} else if (message.subtype === 'match_init_setting') {
 							sendGameStartRequest();
 						} else if (message.subtype === 'match_run') {
 							renderThreeJs(message.data);
@@ -423,6 +425,8 @@ class GamePage {
 							player1Score.textContent = message.data.player1.score;
 							player2Score.textContent = message.data.player2.score;
 							websocket.send(JSON.stringify(disconnectMessage));
+						} else if (message.subtype === 'error') {
+							console.log("server: " + message.message);
 						}
 						break;
 

--- a/GAME/websocket/consumers.py
+++ b/GAME/websocket/consumers.py
@@ -6,7 +6,7 @@ from match.match_manager import MatchManager
 
 class GameConsumer(AsyncWebsocketConsumer):
     def __init__(self, *args, **kwargs):
-        super().__init__(args, kwargs)
+        super().__init__(*args, **kwargs)
         self.match_manager = None
         self.game_session = None
 


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

게임 서버 웹 소켓 코드 리팩토링

## 🧑‍💻 PR 세부 내용

- 확장을 고려하여 메시지 전송부 및 분기 메서드 분리
- 패들색과 배경색, 배틀모드를 클라이언트가 전송한 초기값을 그대로 사용하도록 변경
- 통신 중 예외가 발생 시 연결을 종료하도록 설정
- 웹소켓 연결 시 규약 변경: 클라이언트 웹 소켓 코드 수정
  - 메시지 전송 시 일관성이 떨어진다고 판단하여 수정
  - 게임에 사용되는 모든 규약의 type을 game으로 보기

### 수정된 규약
```json
{
  "type": "game",
  "subtype": "connection_established",
  "message": "You are now connected!"
}
```

### Todo

- 이후 클라이언트가 보내는 게임 난이도 정보를 MatchManager에서 반영할 수 있도록 수정해야 할 것 같습니다.

## 📸 스크린샷

보여줄게 없워용..

## 📚 관련 이슈

- close: #41
