### PR TITLE
[Fix] 공이 벽을 뚫고 무한 반사하는 문제 해결

### DIFF
--- a/GAME/Makefile
+++ b/GAME/Makefile
@@ -4,6 +4,9 @@ all:
 	@make type
 	@make test
 
+run:
+	venv/bin/python manage.py runserver
+
 format:
 	@echo "Formatting code with black"
 	@venv/bin/black --line-length 100 .
@@ -22,4 +25,4 @@ test:
 	@echo "Running Django unit tests"
 	@venv/bin/python manage.py test
 
-.PHONY: all format lint typecheck test
+.PHONY: all format lint typecheck test run

--- a/GAME/match/ball.py
+++ b/GAME/match/ball.py
@@ -3,6 +3,8 @@ from typing import Final
 import math
 import random
 
+from .constants import SCREEN_HEIGHT
+
 
 class Ball:
     INIT_BALL_SPEED: Final = 0.02
@@ -35,6 +37,12 @@ class Ball:
     def move_pos(self) -> None:
         self._x += self._dx
         self._y += self._dy
+
+        ball_y_bound = self.ball_y_bound
+        if ball_y_bound <= self._y:
+            self._y = ball_y_bound
+        elif self._y <= -ball_y_bound:
+            self._y = -ball_y_bound
 
     def increase_speed(self) -> None:
         if self._speed == Ball.INIT_BALL_SPEED:
@@ -92,3 +100,8 @@ class Ball:
     @property
     def max_speed_list(self) -> list:
         return self._max_speed_list
+
+    @property
+    def ball_y_bound(self) -> float:
+        """실제 멤버변수 getter가 아닌 계산 값 반환"""
+        return SCREEN_HEIGHT / 2 - self._radius

--- a/GAME/match/match_manager.py
+++ b/GAME/match/match_manager.py
@@ -156,11 +156,11 @@ class MatchManager:
         self.ball.update_max_speed_list()
 
     def is_ball_colliding_with_wall(self) -> bool:
-        """벽 충돌 확인"""
-        half_width = SCREEN_HEIGHT / 2
-        return (
-            self.ball.y <= -half_width + self.ball.radius
-            or half_width - self.ball.radius <= self.ball.y
+        """벽과 공의 충돌 여부 확인"""
+        ball_y_bound = self.ball.ball_y_bound
+
+        return (self.ball.y <= -ball_y_bound and self.ball.dy < 0) or (
+            ball_y_bound <= self.ball.y and 0 < self.ball.dy
         )
 
     def is_player1_score(self) -> bool:


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

공이 벽을 뚫고 무한 반사하는 문제 해결

## 🧑‍💻 PR 세부 내용

> 자세한 해결 과정 참고 : [개발 일지](https://lowly-crepe-78b.notion.site/bc7da9de526e4a61ac0df3d40619ef54?pvs=4)

**[ 문제점 ]**

- 공과 벽의 충돌을 판단할 때 공의 이동방향을 고려하지 않음
- 공의 좌표를 변화시킬 때 스크린을 벗어났는지 확인하지 않음

**[ 해결 ]**

1. 공과 벽의 충돌 여부를 판단할 때 공의 이동방향을 고려
    - 공의 dy 부호 값을 확인하여 벽에 부딪히는 이동방향인지 확인

    ```python
    def is_ball_colliding_with_wall(self) -> bool:
        """벽 충돌 확인"""
        ball_y_bound = self.ball.ball_y_bound
    
        return (self.ball.y <= -ball_y_bound and self.ball.dy < 0) or (
            ball_y_bound <= self.ball.y and 0 < self.ball.dy
        )
    ```
    
2. 공의 좌표가 스크린을 벗어난 경우 스크린 내부 좌표로 값을 할당
    - 벽에 부딪혔다고 판단하는 경우는 y좌표만을 확인하기 때문에 이에 대한 조건문 추가
    - x 좌표가 스크린을 벗어난 경우 득점으로 판단하기 때문에 변경이 필요하지 않음
    - `@property`를 활용하여 `ball_y_bound` `getter` 구현
      - 공의 y좌표가 위치할 수 있는 최대값을 의미
      - 실제 멤버변수 getter가 아닌 계산 값 반환
      
    ```python
    def move_pos(self) -> None:
        self._x += self._dx
        self._y += self._dy
    
        ball_y_bound = self.ball_y_bound
        if ball_y_bound <= self._y:
            self._y = ball_y_bound
        elif self._y <= -ball_y_bound:
          self._y = -ball_y_bound
    
    @property
    def ball_y_bound(self) -> float:
        return SCREEN_HEIGHT / 2 - self._radius
    ```

**[ 기타 수정사항 ]**
- makefile에 게임 서버 실행을 위한 명령어가 포함된 run 규칙 추가
  - 프론트 분들이 돌릴 때 매번 명령어를 치기 번거로울 것 같아 추가해두었습니다.

## 📸 스크린샷
(은 없습니다..)

사실 버그가 일어나는 경우를 찾기 위해 혼자 계속 게임을 진행했는데요..! 그래서 확실하게 고치고자 이유를 명확히 했습니다.
실제로 잘 동작하는지, 이러한 문제가 잘 고쳐졌는지에 대한 여부는 직접 실행하면서 확인해야하기에..!
혹시나 또 버그가 발생한다면 제보 부탁드립니다. 🙇🏻‍♀️

## 📚 관련 이슈

close #39
