### PR TITLE
[Feat] 토너먼트 대진표 UI

### DIFF
--- a/FE/.eslintrc.js
+++ b/FE/.eslintrc.js
@@ -14,6 +14,8 @@ module.exports = {
 		'no-restricted-globals': 'off',
 		'no-new': 'off',
 		'class-methods-use-this': 'off',
-		'import/no-cycle': 'off'
+		'import/no-cycle': 'off',
+		'no-restricted-syntax': 'off',
+		'no-continue': 'off'
 	}
 };

--- a/FE/public/css/styles.css
+++ b/FE/public/css/styles.css
@@ -370,9 +370,8 @@ td {
 
 /* Path: FE/public/css/style.css */
 
-
 /* GameSettingPage*/
-.button-head-count{
+.button-head-count {
 	display: flex;
 	width: 28rem;
 	padding: 2.12rem 0rem 2.18rem 0rem;
@@ -381,14 +380,13 @@ td {
 	flex-shrink: 0;
 }
 
-.horizontal-button-container{
+.horizontal-button-container {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
 }
 
-
-.game-setting-nickname-container{
+.game-setting-nickname-container {
 	display: flex;
 	width: 60rem;
 	height: 36rem;
@@ -398,10 +396,10 @@ td {
 
 	gap: 3.5rem;
 	border-radius: 1rem;
-	border: 0.2rem solid #FFF;
+	border: 0.2rem solid #fff;
 }
 
-.game-setting-content-container{
+.game-setting-content-container {
 	display: flex;
 	width: 60rem;
 	flex-direction: column;
@@ -409,7 +407,7 @@ td {
 	gap: 5rem;
 }
 
-.vertical-button-container{
+.vertical-button-container {
 	display: flex;
 	height: 15rem;
 	flex-direction: column;
@@ -417,7 +415,7 @@ td {
 	align-items: center;
 }
 
-.game-setting-container{
+.game-setting-container {
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
@@ -427,7 +425,7 @@ td {
 	align-self: stretch;
 }
 
-.game-setting-window{
+.game-setting-window {
 	display: flex;
 	width: 80rem;
 	height: 88rem;
@@ -437,23 +435,23 @@ td {
 	gap: 1rem;
 	flex-shrink: 0;
 	border-radius: 3rem;
-	border: 0.4rem solid #FFF;
-	background: rgba(255, 255, 255, 0.00);
+	border: 0.4rem solid #fff;
+	background: rgba(255, 255, 255, 0);
 }
 /* GameSettingPage*/
 
 /* GameSettingDetailed */
 
-.button-select{
+.button-select {
 	width: 16rem;
 	height: 10rem;
 	/*padding: 4rem 6rem;*/
 	font-size: 2.4rem;
 	border-radius: 3rem;
-	border: 0.2rem solid #FFF;
+	border: 0.2rem solid #fff;
 }
 
-.button-reset-complete{
+.button-reset-complete {
 	display: flex;
 	width: 24rem;
 	padding: 1.6rem 0rem;
@@ -463,10 +461,9 @@ td {
 }
 
 /* light-24px-10% */
-.text-subtitle-1
-{
+.text-subtitle-1 {
 	width: 8rem;
-	color: #FFF;
+	color: #fff;
 	text-align: center;
 	font-size: 2.4rem;
 	font-style: normal;
@@ -475,24 +472,28 @@ td {
 	letter-spacing: 0.24rem;
 }
 
-.width-66{
+.width-66 {
 	width: 66rem;
 }
-.width-54{
+.width-54 {
 	width: 54rem;
 }
 
-.width-28{
+.width-28 {
 	width: 28rem;
 }
 
-.height-25{
+.height-25 {
 	height: 25rem;
 }
 
 .selected {
-	box-shadow: 0rem 0rem 1.5rem 0rem #FF5D84, 0rem 0rem 1.5rem 0rem #FF5D84;
-	text-shadow: 0rem 0rem 1rem #FF5D84, 0rem 0rem 1rem #FF5D84;
+	box-shadow:
+		0rem 0rem 1.5rem 0rem #ff5d84,
+		0rem 0rem 1.5rem 0rem #ff5d84;
+	text-shadow:
+		0rem 0rem 1rem #ff5d84,
+		0rem 0rem 1rem #ff5d84;
 	font-size: 2.4rem;
 	font-style: normal;
 	font-weight: 300;
@@ -505,7 +506,7 @@ td {
 	height: 0;
 }
 
-.color-display-back{
+.color-display-back {
 	display: flex;
 	width: 30rem;
 	height: 25rem;
@@ -513,11 +514,85 @@ td {
 	justify-content: flex-end;
 	align-items: center;
 }
-.color-display-paddle{
+.color-display-paddle {
 	width: 3rem;
 	height: 12rem;
 	flex-shrink: 0;
 	/* yellow_neon_10 */
 	/* box-shadow: 0px 0px 10px 0px #FFD164, 0px 0px 10px 0px #FFD164; */
 }
+
+/* Tournament */
+.tournament-bracket {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	width: 100%;
+	height: 100%;
+}
+
+.user-container {
+	width: 14rem;
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	position: relative;
+}
+
+.user-wrapper {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	overflow-x: hidden;
+	width: 100%;
+	height: 4rem;
+	padding: 0 1rem;
+	margin: auto 0;
+	border-radius: 1rem;
+	border: 0.2rem solid #ffffff;
+}
+
+.user-wrapper-position {
+	width: 100%;
+	height: 4rem;
+	padding: 0 1rem;
+	margin: auto 0;
+	border-radius: 1rem;
+	border: 0.2rem solid #ffffff;
+	position: absolute;
+}
+
+.wire-container {
+	width: 6rem;
+	height: 44.6rem;
+	position: relative;
+}
+
+.wire-wrapper {
+	display: flex;
+	align-items: center;
+	width: 100%;
+	position: absolute;
+}
+
+.wire-rectangle {
+	width: 60%;
+	height: 100%;
+	border-top: 0.3rem solid #ffffff;
+	border-right: 0.3rem solid #ffffff;
+	border-bottom: 0.3rem solid #ffffff;
+}
+
+.wire-solid-line {
+	width: 40%;
+	border-top: 0.3rem solid #ffffff;
+}
+
+.wire-dotted-line {
+	width: 100%;
+	border-top: 0.3rem dotted #ffffff;
+}
+
 /* GameSettingDetailed */

--- a/FE/src/components/TournamentBracket.js
+++ b/FE/src/components/TournamentBracket.js
@@ -1,0 +1,46 @@
+class TournamentBracket {
+	template() {
+		const html = String.raw;
+		/* MOCK DATA */
+		const userNickname = [
+			'player1',
+			'player2',
+			'player3',
+			'player4',
+			'player5',
+			'player6',
+			'player7'
+			// 'player8'
+		];
+		const playerCount = userNickname.length;
+		let userWrappers = '';
+		for (let i = 0; i < userNickname.length; i += 1) {
+			userWrappers += `<div class="user-wrapper head_blue_neon_15"><p>${userNickname[i]}</p></div>`;
+		}
+
+		if (playerCount <= 4) {
+			return html`
+				<div class="tournament-bracket">
+					<div class="user-container">${userWrappers}</div>
+					<div class="wire-container"></div>
+					<div class="user-container"></div>
+					<div class="wire-container"></div>
+					<div class="user-container"></div>
+				</div>
+			`;
+		}
+		return html`
+			<div class="tournament-bracket">
+				<div class="user-container">${userWrappers}</div>
+				<div class="wire-container"></div>
+				<div class="user-container"></div>
+				<div class="wire-container"></div>
+				<div class="user-container"></div>
+				<div class="wire-container"></div>
+				<div class="user-container"></div>
+			</div>
+		`;
+	}
+}
+
+export default TournamentBracket;

--- a/FE/src/index.js
+++ b/FE/src/index.js
@@ -8,6 +8,7 @@ import GameSettingPage from './pages/GameSettingPage.js';
 import GameSettingDetailed from './pages/GameSettingDetailed.js';
 import MatchModePage from './pages/MatchModePage.js';
 import DuelStatsPage from './pages/DuelStatsPage.js';
+import TournamentPage from './pages/TournamentPage.js';
 
 // Shows loading message for 2 seconds
 const loadingContainer = document.querySelector('.loading-container');
@@ -33,7 +34,8 @@ const routes = {
 	play: PlayModePage,
 	match: MatchModePage,
 	game: GamePage,
-	duelstats: DuelStatsPage
+	duelstats: DuelStatsPage,
+	tournament: TournamentPage
 };
 
 // When the page is loaded, the root element is filled with the template of the current page
@@ -44,6 +46,9 @@ routes[''].addEventListeners();
 export const changeUrl = (url) => {
 	history.pushState(null, null, `${homeLink}${url}`);
 	root.innerHTML = routes[url].template();
+	if (typeof routes[url].mount === 'function') {
+		routes[url].mount();
+	}
 	routes[url].addEventListeners();
 };
 

--- a/FE/src/pages/MatchModePage.js
+++ b/FE/src/pages/MatchModePage.js
@@ -7,7 +7,7 @@ const html = String.raw;
 class MatchModePage {
 	template() {
 		const duelButton = new ButtonLarge('1 vs 1', false);
-		const tournamentButton = new ButtonLarge('토너먼트', true);
+		const tournamentButton = new ButtonLarge('토너먼트', false);
 		const backButton = new ButtonBackArrow();
 
 		return html`
@@ -30,7 +30,7 @@ class MatchModePage {
 		});
 		const tournament = document.querySelector('.button-click-tournament');
 		tournament.addEventListener('click', () => {
-			console.log('tournament button click!');
+			changeUrl('tournament');
 		});
 		const back = document.querySelector('.back-arrow-container');
 		back.addEventListener('click', () => {

--- a/FE/src/pages/TournamentPage.js
+++ b/FE/src/pages/TournamentPage.js
@@ -1,0 +1,121 @@
+import { changeUrl } from '../index.js';
+import BoldTitle from '../components/BoldTitle.js';
+import ButtonSmall from '../components/ButtonSmall.js';
+import TournamentBracket from '../components/TournamentBracket.js';
+
+const html = String.raw;
+
+function addUserBracket(position, halfHeight, child) {
+	for (let i = 0; i < position.length; i += 1) {
+		const topPosition = position[i] - halfHeight;
+		const userWrapper = document.createElement('div');
+		userWrapper.classList.add('user-wrapper-position');
+		userWrapper.classList.add('head_blue_neon_15');
+		userWrapper.style.top = `${topPosition}px`;
+		userWrapper.style.left = '0';
+		child.appendChild(userWrapper);
+	}
+}
+
+function addWireBracket(position, child) {
+	let odd = false;
+	if (position.length % 2 === 1) odd = true;
+	const newPosition = [];
+
+	for (let i = 0; i < position.length; ) {
+		if (odd === true && i === 2) {
+			const topPosition = position[i];
+			const wireWrapper = document.createElement('div');
+			wireWrapper.classList.add('wire-wrapper');
+			wireWrapper.style.top = `${topPosition}px`;
+			wireWrapper.style.left = '0';
+			wireWrapper.innerHTML = '<div class="wire-dotted-line"></div>';
+			child.appendChild(wireWrapper);
+			newPosition.push(topPosition);
+			i += 1;
+		} else {
+			const topPosition = position[i];
+			const bottomPosition = position[i + 1];
+			const mid = (topPosition + bottomPosition) / 2;
+			const height = bottomPosition - topPosition;
+			const wireWrapper = document.createElement('div');
+			wireWrapper.classList.add('wire-wrapper');
+			wireWrapper.style.top = `${topPosition}px`;
+			wireWrapper.style.left = '0';
+			wireWrapper.style.height = `${height}px`;
+			wireWrapper.innerHTML = `
+					<div class="wire-rectangle"></div>
+					<div class="wire-solid-line"></div>`;
+			child.appendChild(wireWrapper);
+			newPosition.push(mid);
+			i += 2;
+		}
+	}
+	position.splice(0, position.length, ...newPosition);
+}
+
+function getUserPosition() {
+	const userContainer = document.querySelector('.user-container');
+	const userContainerRect = userContainer.getBoundingClientRect();
+	const parentY = userContainerRect.y;
+	const position = [];
+
+	let halfHeight;
+	const userWrappers = document.querySelectorAll('.user-wrapper');
+	userWrappers.forEach((child) => {
+		const childRect = child.getBoundingClientRect();
+		halfHeight = childRect.height / 2;
+		const childY = childRect.y + halfHeight;
+		const relativeY = childY - parentY;
+		position.push(relativeY);
+	});
+	return { position, halfHeight };
+}
+
+class TournamentPage {
+	template() {
+		const titlComponent = new BoldTitle('대진표', 'yellow');
+		const nextButton = new ButtonSmall('다음');
+
+		const tournamentBracket = new TournamentBracket();
+
+		return html`
+			<div class="medium-window head_white_neon_15">
+				${titlComponent.template()}
+				<div class="medium-window-container display-light18">
+					${tournamentBracket.template()}
+				</div>
+				<div class="event-click-match" style="margin-top: 4rem">
+					${nextButton.template()}
+				</div>
+			</div>
+		`;
+	}
+
+	addEventListeners() {
+		const next = document.querySelector('.event-click-match');
+		next.addEventListener('click', () => {
+			changeUrl('');
+		});
+	}
+
+	mount() {
+		const { position, halfHeight } = getUserPosition();
+		const tournamentBracket = document.querySelector('.tournament-bracket');
+		const userWireContainer = tournamentBracket.children;
+		let firstChildPassed = false;
+		for (const child of userWireContainer) {
+			if (firstChildPassed === false) {
+				firstChildPassed = true;
+				continue;
+			}
+			if (child.classList.contains('user-container')) {
+				addUserBracket(position, halfHeight, child);
+			} else if (child.classList.contains('wire-container')) {
+				addWireBracket(position, child);
+			}
+		}
+	}
+}
+
+export default new TournamentPage();


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

토너먼트 대진표 UI 구현

## 🧑‍💻 PR 세부 내용

- 토너먼트 대진표 유저의 수 만큼 대진표가 자동적으로 그려지게끔 설계
   - FE/src/components/TournamentBracket.js 안에 Mock Data 주석 달아 놓은 곳의 player를 수정해서 잘 나오는지 확인해보세요~! 
- eslint Rule : for..of 문, contiue 코드 off 

## 📸 스크린샷

https://github.com/authenticity-house/ft_transcendence/assets/83465749/6638e80e-ab8d-4880-a9ea-dfd569132cb1

## 📚 관련 이슈

close #52 