### PR TITLE
[Feat] CCW 알고리즘으로 패들 충돌 판별

### DIFF
--- a/GAME/match/coor_util.py
+++ b/GAME/match/coor_util.py
@@ -1,0 +1,26 @@
+from typing import NamedTuple
+
+
+class Point(NamedTuple):
+    x: float
+    y: float
+
+
+def calculate_bounds_rect(point: Point, width: float, height: float, ball_radius: float) -> list:
+    left_x = point.x - (width / 2 + ball_radius)
+    right_x = point.x + (width / 2 + ball_radius)
+    top_y = point.y + (height / 2 + ball_radius)
+    bottom_y = point.y - (height / 2 + ball_radius)
+    return [left_x, right_x, top_y, bottom_y]
+
+
+def line_intersect(seg1_start: Point, seg1_end: Point, seg2_start: Point, seg2_end: Point) -> bool:
+    """선분 (seg1_start)-(seg1_end)와 선분 (seg2_start)-(seg2_end)가 교차하는지 확인"""
+
+    def ccw(p1: Point, p2: Point, p3: Point) -> float:
+        return p1.x * p2.y + p2.x * p3.y + p3.x * p1.y - p2.x * p1.y - p3.x * p2.y - p1.x * p3.y > 0
+
+    case1: bool = ccw(seg1_start, seg1_end, seg2_start) != ccw(seg1_start, seg1_end, seg2_end)
+    case2: bool = ccw(seg1_start, seg1_end, seg2_start) != ccw(seg1_end, seg2_end, seg2_start)
+
+    return case1 and case2

--- a/GAME/websocket/consumers.py
+++ b/GAME/websocket/consumers.py
@@ -5,6 +5,8 @@ from json.decoder import JSONDecodeError
 from channels.generic.websocket import AsyncWebsocketConsumer
 from channels.exceptions import StopConsumer
 from match.match_manager import MatchManager
+from match.player import Player
+from match.ball import Ball
 
 
 class GameConsumer(AsyncWebsocketConsumer):
@@ -71,6 +73,10 @@ class GameConsumer(AsyncWebsocketConsumer):
         background_color = color_info["background"]
         # 아직 공 색 정보는 클라이언트에게 안받음
 
+        ball: Ball = self.match_manager.ball
+        player1: Player = self.match_manager.player1
+        player2: Player = self.match_manager.player2
+
         await self.send(
             text_data=json.dumps(
                 {
@@ -87,25 +93,25 @@ class GameConsumer(AsyncWebsocketConsumer):
                         },
                         "ball": {
                             "status": "in",
-                            "x": 0.0,
-                            "y": 0.0,
-                            "radius": 0.04,
+                            "x": ball.x,
+                            "y": ball.y,
+                            "radius": ball.radius,
                         },
                         "paddle1": {
-                            "x": -2.8,
-                            "y": 0.0,
-                            "width": 0.1,
-                            "height": 0.5,
+                            "x": player1.paddle.x,
+                            "y": player1.paddle.y,
+                            "width": player1.paddle.width,
+                            "height": player1.paddle.height,
                         },
                         "paddle2": {
-                            "x": 2.8,
-                            "y": 0.0,
-                            "width": 0.1,
-                            "height": 0.5,
+                            "x": player2.paddle.x,
+                            "y": player2.paddle.y,
+                            "width": player2.paddle.width,
+                            "height": player2.paddle.height,
                         },
                         "nickname": {
-                            "player1": self.match_manager.player1.name,
-                            "player2": self.match_manager.player2.name,
+                            "player1": player1.name,
+                            "player2": player2.name,
                         },
                     },
                 }


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

CCW 알고리즘으로 패들 충돌 판별하도록 로직 수정

## 🧑‍💻 PR 세부 내용

**[ CCW 알고리즘으로 패들 충돌 판별 ]**

> 자세한 해결 과정 참고 : [학습 + 개발 일지](https://www.notion.so/CCW-6a22a19026574fcaadd319f705365c7c?pvs=4)

- 공 속도가 공의 가로 길이보다 커지면 패들을 관통하는 버그 해결을 위함
- 패들의 테두리와 공의 이동 선분의 교차여부를 확인
- 추가로 좌표 계산 함수 모듈화(`coor_util.py`)
  - 함수의 매개변수가 많아져 Point라는 클래스를 좌표 계산 시 사용 

<img width=400 src="https://github.com/authenticity-house/ft_transcendence/assets/44529556/58c86a29-5a5d-4cf1-8b25-4ae6465f2400" />
<br><br>

**[ 게임 초기 설정 실제 정보 반영 ]**
- 클라이언트에게 전송하는 정보를 MatchManager가 가진 정보를 반영하도록 수정
- 확인해보니 클라이언트에서도 상수값을 사용하기 때문에 반영 필요함

## 📸 스크린샷

<img width="700" alt="스크린샷 2024-03-18 오후 10 00 52" src="https://github.com/authenticity-house/ft_transcendence/assets/44529556/cc22006e-81c3-477d-92bb-4d04214f576b">

## 📚 관련 이슈

- #45 
