### PR TITLE
[Feat] 로컬 게임 나가기 구현

### DIFF
--- a/FE/src/pages/GamePage.js
+++ b/FE/src/pages/GamePage.js
@@ -472,7 +472,7 @@ class GamePage {
 		const returnButton = document.querySelector('.return-button');
 		returnButton.addEventListener('click', () => {
 			const disconnectMessage = {
-				type: "disconnect",
+				type: 'disconnect',
 				message: "I'm leaving!"
 			};
 			websocket.send(JSON.stringify(disconnectMessage));

--- a/FE/src/pages/GamePage.js
+++ b/FE/src/pages/GamePage.js
@@ -472,8 +472,8 @@ class GamePage {
 		const returnButton = document.querySelector('.return-button');
 		returnButton.addEventListener('click', () => {
 			const disconnectMessage = {
-				type: 'disconnect',
-				message: 'I\'m leaving!'
+				type: "disconnect",
+				message: "I'm leaving!"
 			};
 			websocket.send(JSON.stringify(disconnectMessage));
 			websocket.close();

--- a/FE/src/pages/GamePage.js
+++ b/FE/src/pages/GamePage.js
@@ -472,6 +472,12 @@ class GamePage {
 		// Return to the main page
 		const returnButton = document.querySelector('.return-button');
 		returnButton.addEventListener('click', () => {
+			const disconnectMessage = {
+				type: 'disconnect',
+				message: 'I\'m leaving!'
+			};
+			websocket.send(JSON.stringify(disconnectMessage));
+			websocket.close();
 			changeUrl('');
 		});
 	}

--- a/GAME/match/match_manager.py
+++ b/GAME/match/match_manager.py
@@ -5,6 +5,8 @@ import datetime as dt
 from django.utils import timezone
 from channels.generic.websocket import AsyncWebsocketConsumer
 
+# from websocket.consumers import GameConsumer
+
 from .player import Player
 from .paddle import Paddle
 from .ball import Ball
@@ -14,7 +16,7 @@ from .constants import Position, SCREEN_HEIGHT, SCREEN_WIDTH
 class MatchManager:
     def __init__(
         self,
-        socket: AsyncWebsocketConsumer,
+        socket,
         total_score: int = 15,
         player1_name: str = "player1",
         player2_name: str = "player2",
@@ -85,17 +87,8 @@ class MatchManager:
                 "latest": 1,
             },
         }
-        await self.socket.send(
-            text_data=json.dumps(
-                {
-                    "type": "game",
-                    "subtype": "match_run",
-                    "message": "local match running!",
-                    "match_id": 1,
-                    "data": data,
-                }
-            )
-        )
+
+        await self.socket.send_message("match_run", "local match running!", data)
         # FPS 설정 (60프레임)
         await asyncio.sleep(1 / 60)
 
@@ -117,17 +110,7 @@ class MatchManager:
         }
         print(data)
 
-        await self.socket.send(
-            text_data=json.dumps(
-                {
-                    "type": "game",
-                    "subtype": "match_end",
-                    "message": "local match end!",
-                    "match_id": 1,
-                    "data": data,
-                }
-            )
-        )
+        await self.socket.send_message("match_end", "local match end!", data)
 
     def handle_paddle_collision(self, owner: Player, other: Player) -> int:
         self.ball.increase_speed()

--- a/GAME/match/match_manager.py
+++ b/GAME/match/match_manager.py
@@ -1,9 +1,7 @@
 import asyncio
 import math
-import json
 import datetime as dt
 from django.utils import timezone
-from channels.generic.websocket import AsyncWebsocketConsumer
 
 # from websocket.consumers import GameConsumer
 

--- a/GAME/websocket/consumers.py
+++ b/GAME/websocket/consumers.py
@@ -79,46 +79,37 @@ class GameConsumer(AsyncWebsocketConsumer):
         player1: Player = self.match_manager.player1
         player2: Player = self.match_manager.player2
 
-        await self.send(
-            text_data=json.dumps(
-                {
-                    "type": "game",
-                    "subtype": "match_init_setting",
-                    "message": "",
-                    "match_id": 123,
-                    "data": {
-                        "battle_mode": msg_data.get("battle_mode"),
-                        "color": {
-                            "paddle": paddle_color,
-                            "background": background_color,
-                            "ball": "#FFFFFF",
-                        },
-                        "ball": {
-                            "status": "in",
-                            "x": ball.x,
-                            "y": ball.y,
-                            "radius": ball.radius,
-                        },
-                        "paddle1": {
-                            "x": player1.paddle.x,
-                            "y": player1.paddle.y,
-                            "width": player1.paddle.width,
-                            "height": player1.paddle.height,
-                        },
-                        "paddle2": {
-                            "x": player2.paddle.x,
-                            "y": player2.paddle.y,
-                            "width": player2.paddle.width,
-                            "height": player2.paddle.height,
-                        },
-                        "nickname": {
-                            "player1": player1.name,
-                            "player2": player2.name,
-                        },
-                    },
-                }
-            )
-        )
+        data = {
+            "battle_mode": msg_data.get("battle_mode"),
+            "color": {
+                "paddle": paddle_color,
+                "background": background_color,
+                "ball": "#FFFFFF",
+            },
+            "ball": {
+                "status": "in",
+                "x": ball.x,
+                "y": ball.y,
+                "radius": ball.radius,
+            },
+            "paddle1": {
+                "x": player1.paddle.x,
+                "y": player1.paddle.y,
+                "width": player1.paddle.width,
+                "height": player1.paddle.height,
+            },
+            "paddle2": {
+                "x": player2.paddle.x,
+                "y": player2.paddle.y,
+                "width": player2.paddle.width,
+                "height": player2.paddle.height,
+            },
+            "nickname": {
+                "player1": player1.name,
+                "player2": player2.name,
+            },
+        }
+        await self.send_message("match_init_setting", "", data)
 
     async def disconnect(self, code):
         self.connected = False

--- a/GAME/websocket/consumers.py
+++ b/GAME/websocket/consumers.py
@@ -141,7 +141,7 @@ class GameConsumer(AsyncWebsocketConsumer):
 
         try:
             await self.send_message("error", error_message)
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-exception-caught
             print(f"Error sending message: {e}")
         finally:
             await self.disconnect(1002)

--- a/GAME/websocket/consumers.py
+++ b/GAME/websocket/consumers.py
@@ -120,6 +120,7 @@ class GameConsumer(AsyncWebsocketConsumer):
                 await self.game_session
             except asyncio.CancelledError:
                 pass  # 게임 세션 취소 성공
+        await super().disconnect(code)
 
     async def send_message(self, subtype, message, data=None):
         if not self.connected:


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

로컬에서 게임 연결 후 나가기 버튼을 눌렀을 때 게임 세션이 종료되는 기능을 추가했습니다.

## 🧑‍💻 PR 세부 내용

### return 버튼 클릭 시 연결을 종료

- 프론트 코드에 return을 누르면 웹소켓으로 disconnect 메시지를 보내도록 추가

### GameConsumer에 현재 연결 상태 저장 변수 추가

- 원인: 클라이언트로 인해 웹소켓이 닫힌 이후에 비동기 task에 의해 send 되는 예외 발생
- 해결
  - GameConsumer에 웹소켓의 현재 상태를 저장하는 변수(connected) 추가
  - connect 메시지가 도착했을 때 True, disconnect 메시지가 도착했을 때 False가 됨
  - connected가 False인 상태에서 웹소켓 통신을 시도한 경우에 무시

### MatchManager가 GameConsumer의 웹소켓 전송 메서드를 사용하도록 수정

- 기존에는 MatchManager가 직접 웹소켓으로 send를 하고 있었음
- GameConsumer의 메서드를 사용하여 전송하도록 수정
  - 이를 통해 웹소켓이 닫힌 경우 send 되는 현상을 방지

### Todo

- MatchManager에서 GameConsumer를 추가하게 되자 서로 참조하는 순환참조 현상이 발생
- 당장 이를 고치기는 어려워 우선 동적 바인딩에 의존하도록 임시 수정
- 리팩토링 과정에서 새로운 객체를 도입해 순환 참조 현상 해결 예정

## 📸 스크린샷

https://github.com/authenticity-house/ft_transcendence/assets/43935708/50ab0501-4d71-47b1-b605-0ccba4ec8ca4


## 📚 관련 이슈

- #55
