### PR TITLE
[Feat] 게임 종료 후 패들 움직이기 추가

### DIFF
--- a/FE/src/pages/GamePage.js
+++ b/FE/src/pages/GamePage.js
@@ -32,9 +32,21 @@ class GamePage {
 			</div>
 			<div
 				class="game-container"
-				style="display: flex; justify-content: center"
-			></div>
-			<div class="result" style="display: flex; justify-content: center"></div>
+				style="position: relative; display: flex; justify-content: center"
+			>
+				<div
+					class="result"
+					style="position: absolute; top: 75%; left: 50%; transform: translate(-50%, -50%); z-index: 1000; display: none;"
+				>
+					<div
+						class="winner pink_neon_10"
+						style="color: white; font-size: 48px;"
+					>
+						Winner!
+					</div>
+				</div>
+			</div>
+
 			<button class="return-button" style="margin: 30px">Return</button>
 		`;
 	}
@@ -305,19 +317,24 @@ class GamePage {
 			websocket.send(JSON.stringify(message));
 		}
 
+		// 게임 종료 시 winner 설정
 		const player1Score = document.querySelector('.player1');
 		const player2Score = document.querySelector('.player2');
+
+		let winner = 0;
+
+		const result = document.querySelector('.result');
+		const totalScore = this.initial.total_score;
 
 		// 화면 렌더링
 		function renderThreeJs(data) {
 			frame += 1;
-
-			// if (winner === 1) {
-			// 	camera.lookAt(paddleMesh1.position);
-			// }
-			// if (winner === 2) {
-			// 	camera.lookAt(paddleMesh2.position);
-			// }
+			if (Number(player1Score.textContent) === totalScore) {
+				winner = 1;
+			}
+			if (Number(player2Score.textContent) === totalScore) {
+				winner = 2;
+			}
 
 			// Camera movement
 			if (frame < 100) {
@@ -367,6 +384,17 @@ class GamePage {
 			player2Score.textContent = score.player2;
 
 			ballLight.position.copy(ballMesh.position);
+
+			if (winner === 1) {
+				camera.position.x = -4;
+				camera.lookAt(paddleMesh1.position);
+				result.style.display = 'block';
+			}
+			if (winner === 2) {
+				camera.position.x = 4;
+				camera.lookAt(paddleMesh2.position);
+				result.style.display = 'block';
+			}
 
 			renderer.render(scene, camera);
 		}

--- a/GAME/match/match_manager.py
+++ b/GAME/match/match_manager.py
@@ -103,6 +103,10 @@ class MatchManager:
         self.is_run = False
         self._end_date = timezone.now()
 
+        for _ in range(180):
+            self.local_move_paddles()
+            await self.send_data()
+
         data = {
             "date": self._start_date.strftime("%Y-%m-%d"),
             "play_time": self.get_play_time(),


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

게임이 종료된 후 3초간 패들 무빙 추가

## 🧑‍💻 PR 세부 내용

### 구현 내용

- 기존에는 게임이 종료되면 바로 통계창으로 넘어갔음
- 변경 로직
  1. 클라이언트는 게임이 종료됐다고 판단하면 승자에게 카메라 포커스
  2. 게임 서버는 게임이 종료된 후 180 프레임동안 공 정지
  3. 게임 서버가 180프레임을 기다린 후 통계 메시지를 보내면 클라이언트는 통계창으로 전환

## 📸 스크린샷


https://github.com/authenticity-house/ft_transcendence/assets/43935708/31e37493-d634-4846-a589-17ca06b89e34



## 📚 관련 이슈

- #54 
