### PR TITLE
[Feat] 게임 페이지 플레이어 닉네임 출력, 득점 시 애니메이션 효과 추가

### DIFF
--- a/FE/public/css/font.css
+++ b/FE/public/css/font.css
@@ -65,6 +65,15 @@
 	letter-spacing: 0.2rem;
 }
 
+.display-light48 {
+	font-family: 'GongGothicLight';
+	font-size: 4.8rem;
+	font-weight: normal;
+	font-style: normal;
+	line-height: normal;
+	letter-spacing: normal;
+}
+
 .display-light32 {
 	font-family: 'GongGothicLight';
 	font-size: 3.2rem;

--- a/FE/public/css/styles.css
+++ b/FE/public/css/styles.css
@@ -513,7 +513,7 @@ td {
 	justify-content: center;
 	align-items: center;
 	gap: 8rem;
-	border: 0.2rem solid var(--white, #FFF);
+	border: 0.2rem solid var(--white, #fff);
 	background: #000;
 }
 
@@ -602,3 +602,53 @@ td {
 	border-top: 0.3rem dotted #ffffff;
 }
 
+/* GamePage.js */
+.game-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	width: 100%;
+}
+
+.score-container {
+	display: flex;
+	justify-content: center;
+	margin: 1rem;
+}
+
+.player1 {
+	margin-right: 4rem;
+}
+
+.player2 {
+	margin-left: 4rem;
+}
+
+@keyframes score_transition {
+	from {
+		text-shadow:
+			0rem 0rem 1rem #ff5d84,
+			0rem 0rem 1rem #ff5d84;
+	}
+	to {
+		text-shadow: none;
+	}
+}
+.score_transition {
+	animation: score_transition 3s;
+}
+
+.game-container {
+	position: relative;
+	display: flex;
+	justify-content: center;
+}
+
+.game-result {
+	position: absolute;
+	top: 75%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	z-index: 1000;
+	display: none;
+}

--- a/FE/public/css/styles.css
+++ b/FE/public/css/styles.css
@@ -605,7 +605,7 @@ td {
 /* GamePage.js */
 .game-header {
 	display: flex;
-	justify-content: space-between;
+	justify-content: space-around;
 	align-items: center;
 	width: 100%;
 }


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

게임 페이지 플레이어 닉네임 출력, 득점 시 애니메이션 효과 추가

## 🧑‍💻 PR 세부 내용

- 게임 페이지 플레이어 닉네임 출력
  - match_init_setting에서 받아온 데이터의 nickname을 활용하여 렌더링
- 득점 시 애니메이션 효과 추가
```css
@keyframes score_transition {
	from {
		text-shadow:
			0rem 0rem 1rem #ff5d84,
			0rem 0rem 1rem #ff5d84;
	}
	to {
		text-shadow: none;
	}
}
.score_transition {
	animation: score_transition 3s;
}
```
  - 같은 애니메이션을 반복 적용하기 위해 기믹 적용
  - https://velog.io/@jminkyoung/TIL-35-JavaScript%EB%A1%9C-CSS-%EC%95%A0%EB%8B%88%EB%A9%94%EC%9D%B4%EC%85%98-%EC%9E%AC%EC%8B%9C%EC%9E%91%ED%95%98%EA%B8%B0


## 📸 스크린샷


https://github.com/authenticity-house/ft_transcendence/assets/49023654/1112f8f9-152b-4760-89a8-6d3cbfe47385



## 📚 관련 이슈

close #40 
