### PR TITLE
[Feat] 게임 설정 페이지 이동시 정보 저장 및 전달

### DIFF
--- a/FE/src/components/InputNickname.js
+++ b/FE/src/components/InputNickname.js
@@ -5,15 +5,29 @@ class InputNickname {
 		this.index = index;
 	}
 
-	containDiv(index) {
+	containDiv(index, nickname) {
 		let res = '';
+		const nicknames = nickname || []; // nicknames가 undefined 또는 null일 경우 빈 배열 사용
+		let col1 = '';
+		let col2 = '';
+
 		for (let i = 1; i <= index; i += 1) {
-			res += `<div class="input-nickname">
+			const nicknameValue = nicknames[i - 1] || '';
+			const inputDiv = `<div class="input-nickname">
 								<p class="text-light-15">${i}</p>
 								<input type="text" class="input-nickname-box text-light-15"
-								style="text-align:left" />
+								style="text-align:left" value="${nicknameValue}" />
 							</div>`;
+
+			if (i <= 4) {
+				col1 += inputDiv;
+			} else if (i <= 8) {
+				col2 += inputDiv;
+			}
 		}
+		res += `<div class="input-nickname-col-1">${col1}</div>`;
+		res += `<div class="input-nickname-col-2">${col2}</div>`;
+
 		return res;
 	}
 

--- a/FE/src/pages/GameSettingDetailed.js
+++ b/FE/src/pages/GameSettingDetailed.js
@@ -21,9 +21,14 @@ function createConfig(texts, classesPrefix, selectedIndices) {
 	}));
 }
 
+function deepCopy(src) {
+	return JSON.parse(JSON.stringify(src));
+}
+
 class GameSettingDetailed {
 	template(initial) {
-		this.data = JSON.parse(JSON.stringify(initial));
+		this.initial = initial;
+		this.data = deepCopy(initial);
 		const scoreTexts = ['5', '10', '15'];
 		const levelTexts = ['쉬움', '보통', '어려움'];
 
@@ -164,12 +169,15 @@ class GameSettingDetailed {
 		);
 		resetButton.addEventListener('click', () => {
 			this.data = {
+				battle_mode: deepCopy(this.initial.battle_mode),
 				total_score: 2,
 				level: 2,
 				color: {
 					paddle: '#5AD7FF',
 					ball: '#FFD164'
-				}
+				},
+				headcount: deepCopy(this.initial.headcount),
+				nickname: deepCopy(this.initial.nickname)
 			};
 			changeUrlData('gameSettingDetailed', this.data);
 		});

--- a/FE/src/pages/GameSettingDetailed.js
+++ b/FE/src/pages/GameSettingDetailed.js
@@ -24,7 +24,6 @@ function createConfig(texts, classesPrefix, selectedIndices) {
 class GameSettingDetailed {
 	template(initial) {
 		this.data = JSON.parse(JSON.stringify(initial));
-		console.log(this.data);
 		const scoreTexts = ['5', '10', '15'];
 		const levelTexts = ['쉬움', '보통', '어려움'];
 

--- a/FE/src/pages/GameSettingTournament.js
+++ b/FE/src/pages/GameSettingTournament.js
@@ -16,7 +16,7 @@ class GameSettingTournament {
 				ball: '#FFD164'
 			},
 			headcount: 4,
-			nickname: []
+			nickname: ['', '', '', '']
 		};
 	}
 
@@ -43,7 +43,7 @@ class GameSettingTournament {
 			{ text: '시작', classes: 'head_blue_neon_15 blue_neon_10' }
 		];
 		const verticalButton = new VerticalButton(virticalbuttonConfigs);
-		const initialIndex = 4;
+		const initialIndex = this.data.headcount;
 		const inputNickname1 = new InputNickname();
 		return html`
 			<div class="game-setting-window head_white_neon_15">
@@ -75,10 +75,10 @@ class GameSettingTournament {
 								<div class="input-nickname-container">
 									<div class="text-subtitle-1 width-14">닉네임 입력</div>
 									<div class="input-nickname-two-col">
-										<div class="input-nickname-col-1">
-											${inputNickname1.containDiv(initialIndex)}
-										</div>
-										<div class="input-nickname-col-2"></div>
+										${inputNickname1.containDiv(
+											initialIndex,
+											this.data.nickname
+										)}
 									</div>
 								</div>
 							</div>
@@ -162,14 +162,6 @@ class GameSettingTournament {
 			changeUrlData('gameSetting', null);
 		});
 
-		// 세부 설정 버튼
-		const detailedButton = document.querySelector(
-			'.verticalButton button:nth-child(1)'
-		);
-		detailedButton.addEventListener('click', () => {
-			changeUrlData('gameSettingDetailed', this.data);
-		});
-
 		function updateNicknamesData(res) {
 			const nicknameInputs = document.querySelectorAll(
 				'.input-nickname input[type="text"]'
@@ -180,6 +172,17 @@ class GameSettingTournament {
 			);
 			res.nickname = Array.from(nicknameInputs).map((input) => input.value);
 		}
+
+		// 세부 설정 버튼
+		const detailedButton = document.querySelector(
+			'.verticalButton button:nth-child(1)'
+		);
+		detailedButton.addEventListener('click', () => {
+			// const newData = this.data;
+			// this.resetData();
+			updateNicknamesData(this.data);
+			changeUrlData('gameSettingDetailed', this.data);
+		});
 
 		// 시작 버튼
 		const startButton = document.querySelector(

--- a/FE/src/pages/GameSettingTournament.js
+++ b/FE/src/pages/GameSettingTournament.js
@@ -121,7 +121,7 @@ class GameSettingTournament {
 			const minusButton = document.querySelector('.minus');
 			const plusButton = document.querySelectorAll('.plus');
 
-			if (count <= 1) minusButton.classList.add('dis');
+			if (count <= 3) minusButton.classList.add('dis');
 			else minusButton.classList.remove('dis');
 
 			plusButton.forEach((button) => {
@@ -136,7 +136,7 @@ class GameSettingTournament {
 			let count = parseInt(input.value, 10);
 
 			if (this.classList.contains('minus')) {
-				if (count > 1) {
+				if (count > 3) {
 					removeInputNickname(count);
 					count -= 1;
 				}


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

게임 설정 페이지 이동시 정보 저장 및 전달

## 🧑‍💻 PR 세부 내용

1. 페이지 이동 시 정보 저장
   토너먼트 초기 데이터 
   ```
   this.initialData = {
			battle_mode: 2,
			total_score: 2,
			level: 2,
			color: {
				paddle: '#5AD7FF',
				ball: '#FFD164'
			},
			headcount: 4,
			nickname: ['', '', '', '']
		};
   ```
   - 1vs1 / 토너먼트 버튼 눌러서 변경시 데이터 초기화
   - 토너먼트 설정창에서 세부 설정 창 혹은 게임 페이지로 이동시 페이지에서 설정된 참여인원 수와 닉네임 저장
  

2. InputNickname
- containDiv(index, nickname)
   -  index만 받아서 index 만큼 입력창을 만드는 부분에서 index와 nickname을 받아서 index만큼 입력창을 만들고, 그에 맞는 nickname을 입력창에 세팅하도록 변경

3. 참여 인원 3 ~ 8으로 제한
 - 참여인원이 3명 이하일 경우 '-' 버튼 비활성화


## 📸 스크린샷

- 참여인원이 3명 이하일 경우 '-' 버튼 비활성화

    <img width="500" alt="image" src="https://github.com/authenticity-house/ft_transcendence/assets/74870834/2231cc9e-4a02-410b-98f9-d00c456deef2">

## 📚 관련 이슈

#47 
