### PR TITLE
[Feat] 토너먼트 경기 결과 요약 페이지 UI 제작 (50%)

### DIFF
--- a/FE/public/css/styles.css
+++ b/FE/public/css/styles.css
@@ -72,7 +72,7 @@ button {
 	color: #fff;
 }
 
-button:hover:not(.button-back-arrow-box) {
+button:hover:not(.button-back-arrow-box):not(.duel-detail-button) {
 	background-color: #fff;
 	color: #141343;
 	cursor: pointer;
@@ -959,4 +959,114 @@ td {
 }
 .score-position-canvas {
 	border: 0.2rem solid white;
+}
+
+/* component - DuelReport */
+.duel-report-container {
+	display: flex;
+	flex-direction: column;
+	width: 78rem;
+	height: 60rem;
+	overflow: scroll;
+}
+
+.duel-report-wrapper {
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+	min-height: 18rem;
+	border-radius: 3rem;
+	border: 0.4rem solid #ffffff;
+	padding: 2rem;
+	margin-bottom: 3rem;
+	position: relative;
+}
+
+.duel-result-container {
+	display: flex;
+	width: 100%;
+	height: 9rem;
+	padding: 0 2rem;
+}
+
+.duel-user-container {
+	display: flex;
+	justify-content: start;
+	align-items: center;
+	width: 45%;
+	height: 100%;
+	border-color: #5ad7ff;
+}
+
+.justify-content-start {
+	justify-content: start;
+}
+
+.justify-content-end {
+	justify-content: end;
+}
+
+.user-image-container {
+	width: 9rem;
+	height: 9rem;
+	border-radius: 50%;
+	border: 1px solid white;
+	background-color: aliceblue;
+}
+
+.user-blank-container {
+	width: 3rem;
+}
+
+.user-nickname-container {
+	display: flex;
+	/* justify-content */
+	width: 16rem;
+}
+
+.duel-score-container {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	width: 12rem;
+	height: 100%;
+}
+
+.duel-score-wrapper {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	width: 4rem;
+}
+
+.duel-date-time-container {
+	display: flex;
+	justify-content: center;
+	align-items: end;
+	width: 100%;
+	height: 100%;
+}
+
+.duel-date-time-wrapper {
+	display: flex;
+	align-items: center;
+	padding: 0 5rem;
+}
+
+.duel-date-time-title {
+	width: 7.2rem;
+	margin-right: 2rem;
+}
+
+.duel-date-time-data {
+	width: 11rem;
+}
+
+.duel-detail-button {
+	border: none;
+	position: absolute;
+	width: 6rem;
+	height: 5rem;
+	right: 5.5rem;
+	bottom: 0.5rem;
 }

--- a/FE/public/image/duel-detail-button.svg
+++ b/FE/public/image/duel-detail-button.svg
@@ -1,0 +1,23 @@
+<svg width="58" height="46" viewBox="0 0 58 46" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Vector" filter="url(#filter0_dd_521_999)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M15.3163 15.3357C15.4164 15.2293 15.5352 15.1448 15.666 15.0872C15.7968 15.0296 15.9371 15 16.0787 15C16.2204 15 16.3606 15.0296 16.4914 15.0872C16.6222 15.1448 16.7411 15.2293 16.8411 15.3357L29.0003 28.2398L41.1595 15.3357C41.2596 15.2294 41.3784 15.1452 41.5092 15.0877C41.6401 15.0302 41.7803 15.0006 41.9218 15.0006C42.0634 15.0006 42.2036 15.0302 42.3344 15.0877C42.4652 15.1452 42.5841 15.2294 42.6842 15.3357C42.7843 15.4419 42.8637 15.568 42.9179 15.7068C42.9721 15.8456 43 15.9944 43 16.1446C43 16.2948 42.9721 16.4436 42.9179 16.5824C42.8637 16.7212 42.7843 16.8473 42.6842 16.9535L29.7627 30.6643C29.6626 30.7707 29.5438 30.8552 29.413 30.9128C29.2822 30.9704 29.1419 31 29.0003 31C28.8586 31 28.7184 30.9704 28.5876 30.9128C28.4568 30.8552 28.3379 30.7707 28.2379 30.6643L15.3163 16.9535C15.2161 16.8474 15.1365 16.7213 15.0822 16.5825C15.0279 16.4437 15 16.2949 15 16.1446C15 15.9943 15.0279 15.8455 15.0822 15.7067C15.1365 15.5679 15.2161 15.4418 15.3163 15.3357Z" fill="white"/>
+</g>
+<defs>
+<filter id="filter0_dd_521_999" x="0" y="0" width="58" height="46" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="7.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_521_999"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="7.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0"/>
+<feBlend mode="normal" in2="effect1_dropShadow_521_999" result="effect2_dropShadow_521_999"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_521_999" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/FE/src/components/DuelReport.js
+++ b/FE/src/components/DuelReport.js
@@ -1,0 +1,68 @@
+const html = String.raw;
+
+function duelResultElement() {
+	return html`
+		<div class="duel-user-container justify-content-start">
+			<div class="user-image-container"></div>
+			<div class="user-blank-container"></div>
+			<div class="user-nickname-container">hello</div>
+		</div>
+		<div class="duel-score-container pink_neon_10">
+			<div class="duel-score-wrapper">2</div>
+			<div class="duel-score-wrapper">:</div>
+			<div class="duel-score-wrapper">2</div>
+		</div>
+		<div class="duel-user-container justify-content-end">
+			<div class="user-nickname-container justify-content-end">hello</div>
+			<div class="user-blank-container"></div>
+			<div class="user-image-container"></div>
+		</div>
+	`;
+}
+
+function duelDateTimeElement() {
+	return html`
+		<div class="duel-date-time-wrapper">
+			<div class="duel-date-time-title">경기 날짜</div>
+			<div class="duel-date-time-data">2024.04.04</div>
+		</div>
+		<div class="duel-date-time-wrapper">
+			<div class="duel-date-time-title">경기 시간</div>
+			<div class="duel-date-time-data">00:00:00</div>
+		</div>
+	`;
+}
+
+function duelCollapseElement() {
+	return html``;
+}
+
+function duelReportWrapper(data) {
+	/* MOCK DATA */
+	const resultElement = duelResultElement(data);
+	const dataTimeElement = duelDateTimeElement(data);
+	const collapseElement = duelCollapseElement(data);
+
+	return html`
+		<div class="duel-report-wrapper">
+			<div class="duel-result-container display-light28">${resultElement}</div>
+			<div class="duel-date-time-container display-light18">
+				${dataTimeElement}
+			</div>
+			<button
+				class="duel-detail-button"
+				data-toggle="collapse"
+				data-target=".duel-collapse-container"
+			>
+				<img
+					src="image/duel-detail-button.svg"
+					alt="back"
+					style="width: 4rem, color:white"
+				/>
+			</button>
+			<div class="duel-collapse-container">${collapseElement}</div>
+		</div>
+	`;
+}
+
+export { duelReportWrapper };

--- a/FE/src/index.js
+++ b/FE/src/index.js
@@ -10,6 +10,7 @@ import GameSettingDetailed from './pages/GameSettingDetailed.js';
 import MatchModePage from './pages/MatchModePage.js';
 import DuelStatsPage from './pages/DuelStatsPage.js';
 import TournamentPage from './pages/TournamentPage.js';
+import TournamentResultPage from './pages/TournamentResultPage.js';
 
 // Shows loading message for 2 seconds
 const loadingContainer = document.querySelector('.loading-container');
@@ -37,7 +38,8 @@ const routes = {
 	match: MatchModePage,
 	game: GamePage,
 	duelstats: DuelStatsPage,
-	tournament: TournamentPage
+	tournament: TournamentPage,
+	tournamentResult: TournamentResultPage
 };
 
 // When the page is loaded, the root element is filled with the template of the current page

--- a/FE/src/pages/LoginPage.js
+++ b/FE/src/pages/LoginPage.js
@@ -46,7 +46,7 @@ class LoginPage {
 	addEventListeners() {
 		const loginButton = document.querySelector('.login-button');
 		loginButton.addEventListener('click', () => {
-			console.log('로그인');
+			changeUrl('tournamentResult');
 		});
 
 		const signupLink = document.querySelector('.login-signup-link');

--- a/FE/src/pages/TournamentResultPage.js
+++ b/FE/src/pages/TournamentResultPage.js
@@ -1,0 +1,37 @@
+import { changeUrl } from '../index.js';
+import BoldTitle from '../components/BoldTitle.js';
+import ButtonSmall from '../components/ButtonSmall.js';
+import { duelReportWrapper } from '../components/DuelReport.js';
+
+const html = String.raw;
+
+class TournamentResultPage {
+	template() {
+		const titlComponent = new BoldTitle('게임 결과', 'yellow');
+		const exitButton = new ButtonSmall('나가기');
+		let duelReports = '';
+		/* MOCK DATA */
+		const data = [0, 1, 2, 3, 4];
+		for (let i = 0; i < data.length; i += 1) {
+			duelReports += duelReportWrapper(data[i]);
+		}
+
+		return html`
+			<div class="medium-window head_white_neon_15">
+				${titlComponent.template()}
+				<div class="duel-report-container display-light18">${duelReports}</div>
+				<div class="exit-button" style="margin-top: 4rem">
+					${exitButton.template()}
+				</div>
+			</div>
+		`;
+	}
+
+	addEventListeners() {
+		const exit = document.querySelector('.exit-button');
+		exit.addEventListener('click', () => {
+			changeUrl('');
+		});
+	}
+}
+export default new TournamentResultPage();


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

- 토너먼트 경기 결과 요약 페이지 UI 제작

## 🧑‍💻 PR 세부 내용
- TournamentResultPage 제작
- DuelReport component 제작 (매치 결과 한개)

---
### 아직 마무리 안된 것
- 디테일 정보 버튼 클릭 시, 통계들을 보여주는 UI 아직 구현하지 못했습니다.
  - DuelStatsPage (단일 경기 결과 페이지) 에서 사용한 통계들이 컴포넌트로 나누어서 작성하지 않았기에 그대로 가져오는 것이 불가한 상태입니다. 
  - 따라서 일단 완성한 UI 먼저 PR 요청 했고, DuelStatsPage 통계 관련 UI 컴포넌트로 나눈 후에, 디테일 정보 통계 UI 를 제작 할 예정입니다.
  
## 📸 스크린샷
- 로그인 페이지 -> 로그인 버튼 클릭 -> 토너먼트 경기 결과 요약 페이지 UI
<img width="528" alt="스크린샷 2024-03-23 오후 4 58 55" src="https://github.com/authenticity-house/ft_transcendence/assets/83465749/2a80dac7-4d05-4121-945d-894977841024">

## 📚 관련 이슈
#77 