### PR TITLE
[Feat] 대진표를 반영하여 토너먼트 진행

### DIFF
--- a/GAME/match/match_manager.py
+++ b/GAME/match/match_manager.py
@@ -96,7 +96,6 @@ class MatchManager:
             "score": {
                 "player1": self.player1.score_point,
                 "player2": self.player2.score_point,
-                "latest": 1,
             },
         }
         return data

--- a/GAME/match/paddle.py
+++ b/GAME/match/paddle.py
@@ -39,6 +39,9 @@ class Paddle:
     def get_edges(self, ball_radius: float) -> list:
         return calculate_bounds_rect(Point(self.x, self.y), self.width, self._height, ball_radius)
 
+    def get_stat_data(self) -> dict[str, float]:
+        return {"x": self._x, "y": self._y, "width": self.width, "height": self._height}
+
     @property
     def x(self) -> float:
         return self._x

--- a/GAME/session/bracket.py
+++ b/GAME/session/bracket.py
@@ -1,0 +1,112 @@
+from collections import deque
+from typing import Final
+
+
+class Bracket:
+    MATCH_PLAYING: Final = "PONG !"
+    MATCH_NOT_START: Final = ""
+
+    def __init__(self, nickname, headcount):
+        self._nickname: list[str] = nickname
+        self._headcount: int = headcount
+        self._bracket: list[list[str]] = []
+        self._match_queue = deque()
+        self._play_match: list[int] = [1, 0, 0]  # [depth, match, idx]
+        self._play_match_nickname: tuple = ("none", "none")
+
+        self.match_making()
+
+    def match_making(self):
+        """(임시)매치 메이킹 함수 (대진표 초기화)"""
+        # depth 0
+        depth0 = []
+        start = 0
+        if self._headcount % 2 == 1:
+            depth0.append([self._nickname[0]])
+            start = 1
+
+        for i in range(start, self._headcount, 2):
+            p1, p2 = self._nickname[i], self._nickname[i + 1]
+            depth0.append([p1, p2])
+            self._match_queue.append((1, p1))
+            self._match_queue.append((1, p2))
+        self._bracket.append(depth0)
+
+        match_cnt = len(depth0)
+        # depth 1 ~ N - 1
+        while 1 < match_cnt:
+            depth = [
+                [Bracket.MATCH_NOT_START, Bracket.MATCH_NOT_START] for _ in range(match_cnt // 2)
+            ]
+            if match_cnt % 2 == 1:
+                depth.append([Bracket.MATCH_NOT_START])
+            self._bracket.append(depth)
+            match_cnt = len(depth)
+
+        # depth N
+        self._bracket.append([[Bracket.MATCH_NOT_START]])
+
+        # 처음 depth 부전승 확인
+        if start == 1:
+            self._match_queue.append((2, self._nickname[0]))
+            self._bracket[1][0][0] = self._nickname[0]
+            self.update_play_match_idx()
+
+    def get_bracket(self) -> list[list[str]]:
+        # 게임 종료
+        if self.is_end:
+            return self._bracket
+
+        p1_depth, p1_nickname = self._match_queue.popleft()
+        p2_depth, p2_nickname = self._match_queue.popleft()
+
+        if p1_depth != p2_depth:
+            self._bracket[p1_depth + 1][-1][0] = p1_nickname
+            self._match_queue.append((p1_depth + 1, p1_nickname))
+            p1_depth, p1_nickname = p2_depth, p2_nickname
+            p2_depth, p2_nickname = self._match_queue.popleft()
+
+        self.set_play_match_depth(p2_depth)
+        self.set_play_match_str(Bracket.MATCH_PLAYING)
+        self._play_match_nickname = (p1_nickname, p2_nickname)
+
+        return self._bracket
+
+    def get_match_nickname(self) -> tuple:
+        return self._play_match_nickname
+
+    def set_winner_nickname(self, nickname) -> str:
+        depth = self._play_match[0]
+        self.set_play_match_str(nickname)
+        # 부전승 체크하고 대진표 업데이트 (하드코딩중)
+        if self.is_walk_over:
+            self._bracket[depth + 1][-1][-1] = nickname
+
+        self.update_play_match_idx()
+        self._match_queue.append((depth + 1, nickname))
+
+    def set_play_match_depth(self, depth: int) -> None:
+        if self._play_match[0] == depth:
+            return
+        self._play_match[0] = depth
+        self._play_match[1] = 0
+        self._play_match[2] = 0
+
+    def update_play_match_idx(self) -> None:
+        self._play_match[2] += 1
+        if self._play_match[2] == 2:
+            self._play_match[1] += 1
+            self._play_match[2] = 0
+
+    def set_play_match_str(self, string: str) -> None:
+        depth, match_num, idx = self._play_match
+        self._bracket[depth][match_num][idx] = string
+
+    @property
+    def is_walk_over(self):
+        depth, match_num, _ = self._play_match
+        return len(self._bracket[depth][match_num]) == 1
+
+    @property
+    def is_end(self):
+        return self._bracket[-1][0][0] not in [Bracket.MATCH_NOT_START, Bracket.MATCH_PLAYING]

--- a/GAME/session/session_manager.py
+++ b/GAME/session/session_manager.py
@@ -91,9 +91,7 @@ class SessionManager:
         return self._summary_stat
 
     def get_level_info(self):
-        """
-        패들 길이, 공 속도, 공 가속도 반환
-        """
+        """패들 길이, 공 속도, 공 가속도 반환"""
         if self._level == 1:
             return 0.5, 0.04, 0.003
         if self._level == 2:
@@ -110,18 +108,8 @@ class SessionManager:
             "battle_mode": self._battle_mode,
             "color": self._color,
             "ball": ball.get_stat_data(),
-            "paddle1": {
-                "x": player1.paddle.x,
-                "y": player1.paddle.y,
-                "width": player1.paddle.width,
-                "height": player1.paddle.height,
-            },
-            "paddle2": {
-                "x": player2.paddle.x,
-                "y": player2.paddle.y,
-                "width": player2.paddle.width,
-                "height": player2.paddle.height,
-            },
+            "paddle1": player1.paddle.get_stat_data(),
+            "paddle2": player2.paddle.get_stat_data(),
             "nickname": {
                 "player1": player1.name,
                 "player2": player2.name,

--- a/GAME/session/session_manager.py
+++ b/GAME/session/session_manager.py
@@ -12,6 +12,7 @@ class SessionManager:
         self._battle_mode = data.get("battle_mode", 1)
         self._match_manager: MatchManager = None
         self._summary_stat = []
+        self._latest_winner = ""
 
         nickname = data.get("nickname", ["player1", "player2"])
         headcount = data.get("headcount", len(nickname))
@@ -23,7 +24,11 @@ class SessionManager:
     # 소켓에서 전송할 데이터 반환
     def get_send_data(self, subtype: str):
         if subtype == "tournament_tree":
-            data = {"battle_mode": self._battle_mode, "depth": self._bracket.get_bracket()}
+            data = {
+                "battle_mode": self._battle_mode,
+                "winner": self._latest_winner,
+                "bracket": self._bracket.get_bracket(),
+            }
             return subtype, "3-1 대진표", data
 
         if subtype == "match_init_setting":
@@ -39,12 +44,16 @@ class SessionManager:
 
             if self.battle_mode == 2:
                 # 이긴 사람에 대해 업데이트 필요함
-                winner = self.get_winner_nickname(data)
-                self._bracket.set_winner_nickname(winner)
+                self._latest_winner = self.get_winner_nickname(data)
+                self._bracket.set_winner_nickname(self._latest_winner)
             return subtype, "5-1 매치 통계 정보 전송", data
 
         if subtype == "next_match":
-            data = {"battle_mode": self._battle_mode, "depth": self._bracket.get_bracket()}
+            data = {
+                "battle_mode": self._battle_mode,
+                "winner": self._latest_winner,
+                "bracket": self._bracket.get_bracket(),
+            }
 
             if self._bracket.is_end:
                 return "tournament_tree", "6-1 대진표", data, "game_over"

--- a/GAME/session/session_manager.py
+++ b/GAME/session/session_manager.py
@@ -91,8 +91,15 @@ class SessionManager:
         return self._summary_stat
 
     def get_level_info(self):
-        """(임시) 패들 길이, 공 속도, 공 가속도 반환"""
-        return 0.5, 0.06, 0.005
+        """
+        패들 길이, 공 속도, 공 가속도 반환
+        """
+        if self._level == 1:
+            return 0.5, 0.04, 0.003
+        if self._level == 2:
+            return 0.4, 0.04, 0.004
+
+        return 0.3, 0.05, 0.004
 
     def get_initial_settings(self):
         ball: Ball = self._match_manager.ball


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

대진표를 반영하여 토너먼트의 각 매치를 순서대로 진행

## 🧑‍💻 PR 세부 내용

### 1. 난이도에 따른 매치 초기 정보 설정
- SessionManager의 `get_level_info()`에서 난이도에 따른 **패들 길이, 공 속도, 공 가속도** 반환
- level 1: 0.5, 0.04, 0.003
- level 2: 0.4, 0.04, 0.004
- level 3: 0.3, 0.05, 0.004


### 2. 토너먼트 대진표를 반영한 매치 진행
- Bracket 클래스 구현
- 현재 대진중인 매치에 대한 정보를 대진표에 추가 : `MATCH_PLAYING: Final = "PONG !"`
- 아직 경기가 진행되지 않은 상태 : `MATCH_NOT_START: Final = ""`
- 대진표를 보낼 때 진행되지 않은 것 또한 모두 형식에 맞춰 보내고 있음(3차원 배열 형태로 전송)
- 매치에서 이긴 사람은 winner로 전송(없다면 `""`)
```json
[
  [
     ["wonyang", "jeongmin"], 
     ["joyoo", "jihylim"]
  ], 
  [
     ["wonyang", "PONG !"]
  ],
 [
    [""]
  ]
]
``` 

### 3. 웹소켓 규약 살짝 수정
- `latest` 정보 제거
- 토너먼트 대진표 전송 시 `winner` 추가, `depth -> bracket`으로 이름 변경
- `bracket` 형식 수정

## 📸 스크린샷

<img width="600" alt="Screen Shot 2024-03-24 at 2 11 01 PM" src="https://github.com/authenticity-house/ft_transcendence/assets/44529556/9817b606-2e7c-44ab-928f-28302775b90c">

<img width=400 src="https://github.com/authenticity-house/ft_transcendence/assets/44529556/29447d20-b955-49e7-9627-1a5f507b3e15">

## 📚 관련 이슈

- #57
