### PR TITLE
[Refactor] 게임 결과 통계 페이지(DuelStatsPage) 리팩토링

### DIFF
--- a/FE/public/css/styles.css
+++ b/FE/public/css/styles.css
@@ -288,8 +288,9 @@ button:hover:not(.button-back-arrow-box):not(.duel-detail-button) {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	width: 74rem;
+	width: 100%;
 	height: 3.5rem;
+	padding: 0 2rem;
 }
 
 .score-board-wrapper {
@@ -315,7 +316,7 @@ td {
 	height: 22rem;
 }
 
-.match-date-time-container {
+.match-date-time-table {
 	display: flex;
 	justify-content: center;
 	align-items: center;
@@ -338,7 +339,7 @@ td {
 	width: 6rem;
 }
 
-.match-rally-container {
+.match-rally-table {
 	display: flex;
 	justify-content: center;
 	align-items: center;
@@ -360,11 +361,11 @@ td {
 	height: 3.6rem;
 }
 
-.special-stats-container td:nth-child(even) {
+.special-stats-table td:nth-child(even) {
 	width: 14rem;
 }
 
-.special-stats-container td:nth-child(odd) {
+.special-stats-table td:nth-child(odd) {
 	width: 20rem;
 }
 
@@ -834,7 +835,7 @@ td {
 	display: flex;
 	justify-content: space-between;
 	width: 100%;
-	height: 50rem;
+	min-height: 45rem;
 }
 
 /* Graph - ScoreTrend */
@@ -923,7 +924,6 @@ td {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	justify-content: center;
 	width: 36.5rem;
 	height: 45rem;
 }

--- a/FE/src/components/DuelBasicStats.js
+++ b/FE/src/components/DuelBasicStats.js
@@ -1,0 +1,79 @@
+const html = String.raw;
+
+class DuelBasicStats {
+	static getScoreBoardHTML(matchData) {
+		return html`
+			<div class="score-board-container display-light28">
+				<div>${matchData.leftPlayer}</div>
+				<ul class="score-board-wrapper pink_neon_10">
+					<li>${matchData.leftScore}</li>
+					<li>:</li>
+					<li>${matchData.rightScore}</li>
+				</ul>
+				<div>${matchData.rightPlayer}</div>
+			</div>
+		`;
+	}
+
+	static getMatchDateTimeHTML(matchData) {
+		return html`
+			<table class="match-date-time-table">
+				<tbody>
+					<tr>
+						<td>경기날짜</td>
+						<td></td>
+						<td>${matchData.matchDate}</td>
+					</tr>
+					<tr class="basic-table-tr-spacer"></tr>
+					<tr>
+						<td>경기시간</td>
+						<td></td>
+						<td>${matchData.matchTime}</td>
+					</tr>
+				</tbody>
+			</table>
+		`;
+	}
+
+	static getMatchRallyHTML(matchData) {
+		return html`
+			<table class="match-rally-table">
+				<tbody>
+					<tr>
+						<td>.</td>
+						<td></td>
+						<td>랠리 횟수</td>
+						<td></td>
+						<td>최대 공속도</td>
+					</tr>
+					<tr class="basic-table-tr-spacer"></tr>
+					<tr>
+						<td>최대</td>
+						<td></td>
+						<td>${matchData.maxRally}</td>
+						<td></td>
+						<td>${matchData.maxMaxBallSpeed.toFixed(2)}</td>
+					</tr>
+					<tr class="basic-table-tr-spacer"></tr>
+					<tr>
+						<td>평균</td>
+						<td></td>
+						<td>${matchData.avgRally.toFixed(2)}</td>
+						<td></td>
+						<td>${matchData.avgMaxBallSpeed.toFixed(2)}</td>
+					</tr>
+					<tr class="basic-table-tr-spacer"></tr>
+					<tr>
+						<td>최소</td>
+						<td></td>
+						<td>${matchData.minRally}</td>
+						<td></td>
+						<td>${matchData.minMaxBallSpeed.toFixed(2)}</td>
+					</tr>
+				</tbody>
+			</table>
+		`;
+	}
+}
+
+export default DuelBasicStats;

--- a/FE/src/components/DuelGraphStats.js
+++ b/FE/src/components/DuelGraphStats.js
@@ -1,6 +1,59 @@
 const html = String.raw;
 
-class GraphScore {
+class DuelGraphStats {
+	static getScoreTrendHTML(matchData) {
+		return html`
+			<div class="score-trend-container">
+				<div class="score-trend-title display-light24">득점 추이</div>
+				<div class="score-trend-canvas-container">
+					<div class="score-trend-canvas-text-container display-light10"></div>
+					<canvas
+						class="score-trend-canvas-draw-container"
+						width="335"
+						height="360"
+					></canvas>
+				</div>
+				<div class="score-trend-player-name-container display-light16">
+					<div class="score-trend-player-name-wrapper">
+						<div class="score-player-name-margin-right">
+							${matchData.leftPlayer}
+						</div>
+						<div class="score-player-color-yellow"></div>
+					</div>
+					<div class="score-trend-player-name-wrapper">
+						<div class="score-player-name-margin-right">
+							${matchData.rightPlayer}
+						</div>
+						<div class="score-player-color-blue"></div>
+					</div>
+				</div>
+			</div>
+		`;
+	}
+
+	static getScorePositionHTML(matchData) {
+		return html`
+			<div class="score-position-container">
+				<div class="score-position-title display-light24">득점 위치</div>
+				<div class="score-position-player-name-container display-light16">
+					<div class="score-position-player-left-wrapper">
+						<div class="score-player-name-margin-right">
+							${matchData.leftPlayer}
+						</div>
+						<div class="score-player-color-yellow"></div>
+					</div>
+					<div class="score-position-player-right-wrapper">
+						<div class="score-player-color-blue"></div>
+						<div class="score-player-name-margin-left">
+							${matchData.rightPlayer}
+						</div>
+					</div>
+				</div>
+				<canvas class="score-position-canvas" width="280" height="360"></canvas>
+			</div>
+		`;
+	}
+
 	static appendScoresToYAxis(maxScore) {
 		const scoreText = document.querySelector(
 			'.score-trend-canvas-text-container'
@@ -134,4 +187,5 @@ class GraphScore {
 		);
 	}
 }
-export default GraphScore;
+
+export default DuelGraphStats;

--- a/FE/src/components/DuelSpecialStats.js
+++ b/FE/src/components/DuelSpecialStats.js
@@ -1,0 +1,53 @@
+const html = String.raw;
+
+class DuelSpecialStats {
+	static getSpecialStatsHTML(matchData) {
+		return html`
+			<table class="special-stats-table display-light18">
+				<tbody>
+					<tr class="display-light24">
+						<td>${matchData.leftPlayer}</td>
+						<td></td>
+						<td>.</td>
+						<td></td>
+						<td>${matchData.rightPlayer}</td>
+					</tr>
+					<tr class="special-table-tr-spacer"></tr>
+					<tr>
+						<td>${matchData.leftAttackType}</td>
+						<td></td>
+						<td>공격성향</td>
+						<td></td>
+						<td>${matchData.rightAttackType}</td>
+					</tr>
+					<tr class="special-table-tr-spacer"></tr>
+					<tr>
+						<td>${matchData.powerUpCnt1}</td>
+						<td></td>
+						<td>파워업 공격 횟수</td>
+						<td></td>
+						<td>${matchData.powerUpCnt2}</td>
+					</tr>
+					<tr class="special-table-tr-spacer"></tr>
+					<tr>
+						<td>${matchData.keyCnt1.toFixed(2)}</td>
+						<td></td>
+						<td>평균 키 입력 횟수</td>
+						<td></td>
+						<td>${matchData.keyCnt2.toFixed(2)}</td>
+					</tr>
+					<tr class="special-table-tr-spacer"></tr>
+					<tr>
+						<td>${matchData.leftAttackPos}</td>
+						<td></td>
+						<td>주요 공격 위치</td>
+						<td></td>
+						<td>${matchData.rightAttackPos}</td>
+					</tr>
+				</tbody>
+			</table>
+		`;
+	}
+}
+
+export default DuelSpecialStats;

--- a/FE/src/components/DuelStatsData.js
+++ b/FE/src/components/DuelStatsData.js
@@ -1,0 +1,83 @@
+class DuelStatsData {
+	static getDuelStatsData(data) {
+		const leftPlayer = data ? data.player1.nickname : '플레이어1';
+		const rightPlayer = data ? data.player2.nickname : '플레이어2';
+		const leftScore = data ? data.player1.score : 0;
+		const rightScore = data ? data.player2.score : 0;
+
+		const winPlayer =
+			leftScore > rightScore ? `${leftPlayer} WIN!` : `${rightPlayer} WIN!`;
+
+		const matchDate = data ? data.date : '2000-00-00';
+		const matchTime = data ? data.play_time : '00:00:00';
+
+		const maxRally = data ? data.rally[0] : 0;
+		const maxMaxBallSpeed = data ? data.max_ball_speed[0] : 0;
+		const avgRally = data ? data.rally[1] : 0;
+		const avgMaxBallSpeed = data ? data.max_ball_speed[1] : 0;
+		const minRally = data ? data.rally[2] : 0;
+		const minMaxBallSpeed = data ? data.max_ball_speed[2] : 0;
+
+		const attackType1 = data ? data.player1.attack_type : 0;
+		const attackType2 = data ? data.player2.attack_type : 0;
+		const attackTypeList = ['공격형', '방어형', '혼합형'];
+		const leftAttackType = attackTypeList[attackType1];
+		const rightAttackType = attackTypeList[attackType2];
+
+		const attackPos1 = data ? data.player1.attack_pos : 0;
+		const attackPos2 = data ? data.player2.attack_pos : 0;
+		const attackPosList = ['상단', '중단', '하단', '전체'];
+		const leftAttackPos = attackPosList[attackPos1];
+		const rightAttackPos = attackPosList[attackPos2];
+
+		const powerUpCnt1 = data ? data.player1.power_up_cnt : 0;
+		const powerUpCnt2 = data ? data.player2.power_up_cnt : 0;
+
+		const keyCnt1 = data ? data.player1.key_cnt : 0;
+		const keyCnt2 = data ? data.player2.key_cnt : 0;
+
+		return {
+			leftPlayer,
+			rightPlayer,
+			leftScore,
+			rightScore,
+			winPlayer,
+			matchDate,
+			matchTime,
+			maxRally,
+			maxMaxBallSpeed,
+			avgRally,
+			avgMaxBallSpeed,
+			minRally,
+			minMaxBallSpeed,
+			leftAttackType,
+			rightAttackType,
+			leftAttackPos,
+			rightAttackPos,
+			powerUpCnt1,
+			powerUpCnt2,
+			keyCnt1,
+			keyCnt2
+		};
+	}
+
+	static getMountDuelStatsData(data) {
+		const leftScoreTrend = data ? data.graph.player1.score_trend : [];
+		const rightScoreTrend = data ? data.graph.player2.score_trend : [];
+		const leftScore = data ? data.player1.score : -1;
+		const rightScore = data ? data.player2.score : -1;
+		const maxScore = leftScore >= rightScore ? leftScore : rightScore;
+
+		const leftPosition = data ? data.graph.player1.score_pos : [];
+		const rightPosition = data ? data.graph.player2.score_pos : [];
+
+		return {
+			leftScoreTrend,
+			rightScoreTrend,
+			maxScore,
+			leftPosition,
+			rightPosition
+		};
+	}
+}
+export default DuelStatsData;

--- a/FE/src/components/GraphScore.js
+++ b/FE/src/components/GraphScore.js
@@ -1,127 +1,137 @@
 const html = String.raw;
 
-function graphScoreText(maxScore) {
-	let scoreTextWrappers = '';
-	for (let score = maxScore; score >= 0; score -= 1) {
-		scoreTextWrappers += `<div class="score-trend-canvas-text-wrapper">${score}</div>`;
+class GraphScore {
+	static appendScoresToYAxis(maxScore) {
+		const scoreText = document.querySelector(
+			'.score-trend-canvas-text-container'
+		);
+
+		let scoreTextWrappers = '';
+		for (let score = maxScore; score >= 0; score -= 1) {
+			scoreTextWrappers += `<div class="score-trend-canvas-text-wrapper">${score}</div>`;
+		}
+		const htmlString = html`${scoreTextWrappers}`;
+		const fragment = document
+			.createRange()
+			.createContextualFragment(htmlString);
+		scoreText.appendChild(fragment);
 	}
-	const htmlString = html`${scoreTextWrappers}`;
-	const fragment = document.createRange().createContextualFragment(htmlString);
-	return fragment;
-}
 
-function getScoreTextPosition() {
-	const scoreParent = document.querySelector(
-		'.score-trend-canvas-text-container'
-	);
-	const scoreParentRect = scoreParent.getBoundingClientRect();
-	const parentY = scoreParentRect.y;
-	const position = [];
+	static getScoreTextPosition() {
+		const scoreParent = document.querySelector(
+			'.score-trend-canvas-text-container'
+		);
+		const scoreParentRect = scoreParent.getBoundingClientRect();
+		const parentY = scoreParentRect.y;
+		const position = [];
 
-	let halfHeight;
-	const scoreTextWrappers = document.querySelectorAll(
-		'.score-trend-canvas-text-wrapper'
-	);
-	scoreTextWrappers.forEach((child) => {
-		const childRect = child.getBoundingClientRect();
-		halfHeight = childRect.height / 2;
-		const childY = childRect.y + halfHeight;
-		const relativeY = childY - parentY;
-		position.unshift(relativeY);
-	});
-	return position;
-}
+		let halfHeight;
+		const scoreTextWrappers = document.querySelectorAll(
+			'.score-trend-canvas-text-wrapper'
+		);
+		scoreTextWrappers.forEach((child) => {
+			const childRect = child.getBoundingClientRect();
+			halfHeight = childRect.height / 2;
+			const childY = childRect.y + halfHeight;
+			const relativeY = childY - parentY;
+			position.unshift(relativeY);
+		});
+		return position;
+	}
 
-function drawScoreTrendCircle(ctx, x, y, color) {
-	ctx.beginPath();
-	ctx.strokeStyle = color;
-	ctx.lineCap = 'round';
-	ctx.arc(x, y, 2, 0, 2 * Math.PI);
-	ctx.stroke();
-	ctx.closePath();
-}
+	static drawScoreTrendCircle(ctx, x, y, color) {
+		ctx.beginPath();
+		ctx.strokeStyle = color;
+		ctx.lineCap = 'round';
+		ctx.arc(x, y, 2, 0, 2 * Math.PI);
+		ctx.stroke();
+		ctx.closePath();
+	}
 
-function drawLine(ctx, x1, y1, x2, y2, color) {
-	ctx.beginPath();
-	ctx.strokeStyle = color;
-	if (color === '#ffffff') ctx.setLineDash([5, 5]);
-	ctx.lineWidth = 2;
-	ctx.lineCap = 'round';
-	ctx.moveTo(x1, y1);
-	ctx.lineTo(x2, y2);
-	ctx.stroke();
-	ctx.closePath();
-}
+	static drawLine(ctx, x1, y1, x2, y2, color) {
+		ctx.beginPath();
+		ctx.strokeStyle = color;
+		if (color === '#ffffff') ctx.setLineDash([5, 5]);
+		ctx.lineWidth = 2;
+		ctx.lineCap = 'round';
+		ctx.moveTo(x1, y1);
+		ctx.lineTo(x2, y2);
+		ctx.stroke();
+		ctx.closePath();
+	}
 
-function graphScoreTrend(leftScoreTrend, rightScoreTrend, position) {
-	const canvas = document.querySelector('.score-trend-canvas-draw-container');
-	const widthCount = leftScoreTrend.length + 1;
-	const widthDivide = canvas.width / widthCount;
+	static appendScoreTrendGraph(leftScoreTrend, rightScoreTrend) {
+		const position = this.getScoreTextPosition();
+		const canvas = document.querySelector('.score-trend-canvas-draw-container');
+		const widthCount = leftScoreTrend.length + 1;
+		const widthDivide = canvas.width / widthCount;
 
-	const ctx = canvas.getContext('2d');
+		const ctx = canvas.getContext('2d');
 
-	for (let i = 0; i < leftScoreTrend.length - 1; i += 1) {
-		// left
-		const x1 = (i + 1) * widthDivide;
-		const x2 = (i + 2) * widthDivide;
-		let y1 = position[leftScoreTrend[i]];
-		let y2 = position[leftScoreTrend[i + 1]];
+		for (let i = 0; i < leftScoreTrend.length - 1; i += 1) {
+			// left
+			const x1 = (i + 1) * widthDivide;
+			const x2 = (i + 2) * widthDivide;
+			let y1 = position[leftScoreTrend[i]];
+			let y2 = position[leftScoreTrend[i + 1]];
 
-		drawScoreTrendCircle(ctx, x1, y1, '#ffd164');
-		drawScoreTrendCircle(ctx, x2, y2, '#ffd164');
-		drawLine(ctx, x1, y1, x2, y2, '#ffd164');
+			this.drawScoreTrendCircle(ctx, x1, y1, '#ffd164');
+			this.drawScoreTrendCircle(ctx, x2, y2, '#ffd164');
+			this.drawLine(ctx, x1, y1, x2, y2, '#ffd164');
 
-		// right
-		y1 = position[rightScoreTrend[i]];
-		y2 = position[rightScoreTrend[i + 1]];
-		drawScoreTrendCircle(ctx, x1, y1, '#5ad7ff');
-		drawScoreTrendCircle(ctx, x2, y2, '#5ad7ff');
-		drawLine(ctx, x1, y1, x2, y2, '#5ad7ff');
+			// right
+			y1 = position[rightScoreTrend[i]];
+			y2 = position[rightScoreTrend[i + 1]];
+			this.drawScoreTrendCircle(ctx, x1, y1, '#5ad7ff');
+			this.drawScoreTrendCircle(ctx, x2, y2, '#5ad7ff');
+			this.drawLine(ctx, x1, y1, x2, y2, '#5ad7ff');
+		}
+	}
+
+	static drawScorePoisitionCircle(ctx, x, y, color) {
+		ctx.beginPath();
+		ctx.strokeStyle = color;
+		ctx.lineCap = 'round';
+		ctx.arc(x, y, 6, 0, 2 * Math.PI);
+		ctx.stroke();
+		ctx.fillStyle = color;
+		ctx.fill();
+		ctx.closePath();
+	}
+
+	static appendScorePositionGraph(leftPosition, rightPosition) {
+		const canvas = document.querySelector('.score-position-canvas');
+		const ctx = canvas.getContext('2d');
+		const canvasHeight = canvas.height;
+		const canvasWidth = canvas.width;
+		const canvasYrange = 4;
+		// leftPosition
+		leftPosition.forEach((position) => {
+			let y = position[1];
+			y *= -1;
+			const canvasY = (canvasHeight * (y + 2)) / canvasYrange;
+			const color = '#ffd164';
+			const canvasX = canvasWidth - 5;
+			this.drawScorePoisitionCircle(ctx, canvasX, canvasY, color);
+		});
+		// rightPosition
+		rightPosition.forEach((position) => {
+			let y = position[1];
+			y *= -1;
+			const canvasY = (canvasHeight * (y + 2)) / canvasYrange;
+			const color = '#5ad7ff';
+			const canvasX = 5;
+			this.drawScorePoisitionCircle(ctx, canvasX, canvasY, color);
+		});
+		// center line
+		this.drawLine(
+			ctx,
+			canvasWidth / 2,
+			0,
+			canvasWidth / 2,
+			canvasHeight,
+			'#ffffff'
+		);
 	}
 }
-
-function drawScorePoisitionCircle(ctx, x, y, color) {
-	ctx.beginPath();
-	ctx.strokeStyle = color;
-	ctx.lineCap = 'round';
-	ctx.arc(x, y, 6, 0, 2 * Math.PI);
-	ctx.stroke();
-	ctx.fillStyle = color;
-	ctx.fill();
-	ctx.closePath();
-}
-
-function graphScorePosition(leftPosition, rightPosition) {
-	const canvas = document.querySelector('.score-position-canvas');
-	const ctx = canvas.getContext('2d');
-	const canvasHeight = canvas.height;
-	const canvasWidth = canvas.width;
-	const canvasYrange = 4;
-	// leftPosition
-	leftPosition.forEach((position) => {
-		let y = position[1];
-		y *= -1;
-		const canvasY = (canvasHeight * (y + 2)) / canvasYrange;
-		const color = '#ffd164';
-		const canvasX = canvasWidth - 5;
-		drawScorePoisitionCircle(ctx, canvasX, canvasY, color);
-	});
-	// rightPosition
-	rightPosition.forEach((position) => {
-		let y = position[1];
-		y *= -1;
-		const canvasY = (canvasHeight * (y + 2)) / canvasYrange;
-		const color = '#5ad7ff';
-		const canvasX = 5;
-		drawScorePoisitionCircle(ctx, canvasX, canvasY, color);
-	});
-	// center line
-	drawLine(ctx, canvasWidth / 2, 0, canvasWidth / 2, canvasHeight, '#ffffff');
-}
-
-export {
-	graphScoreText,
-	getScoreTextPosition,
-	graphScoreTrend,
-	graphScorePosition
-};
+export default GraphScore;

--- a/FE/src/pages/DuelStatsPage.js
+++ b/FE/src/pages/DuelStatsPage.js
@@ -2,8 +2,9 @@ import { changeUrl } from '../index.js';
 import BoldTitle from '../components/BoldTitle.js';
 import ButtonSmall from '../components/ButtonSmall.js';
 import DuelStatsData from '../components/DuelStatsData.js';
-import GraphScore from '../components/GraphScore.js';
-// import
+import DuelBasicStats from '../components/DuelBasicStats.js';
+import DuelSpecialStats from '../components/DuelSpecialStats.js';
+import DuelGraphStats from '../components/DuelGraphStats.js';
 
 const html = String.raw;
 
@@ -12,173 +13,29 @@ class DuelStatsPage {
 		const matchData = DuelStatsData.getDuelStatsData(data);
 
 		/* Components */
-		const titlComponent = new BoldTitle(matchData.winPlayer, 'pink');
+		const titleComponent = new BoldTitle(matchData.winPlayer, 'pink');
+		const scoreBoardHtml = DuelBasicStats.getScoreBoardHTML(matchData);
+		const matchDateTimeHtml = DuelBasicStats.getMatchDateTimeHTML(matchData);
+		const matchRallyHtml = DuelBasicStats.getMatchRallyHTML(matchData);
+		const specialStatsHtml = DuelSpecialStats.getSpecialStatsHTML(matchData);
+		const scoreTrendHtml = DuelGraphStats.getScoreTrendHTML(matchData);
+		const scorePositionHtml = DuelGraphStats.getScorePositionHTML(matchData);
 		const nextButton = new ButtonSmall('다음');
 
 		return html`
 			<div class="medium-window head_white_neon_15">
-				${titlComponent.template()}
+				${titleComponent.template()}
 				<div class="medium-window-container">
-					<div class="score-board-container display-light28">
-						<div>${matchData.leftPlayer}</div>
-						<ul class="score-board-wrapper pink_neon_10">
-							<li>${matchData.leftScore}</li>
-							<li>:</li>
-							<li>${matchData.rightScore}</li>
-						</ul>
-						<div>${matchData.rightPlayer}</div>
-					</div>
+					${scoreBoardHtml}
 					<div class="divider"></div>
 					<div class="basic-stats-container display-light18">
-						<div class="match-date-time-container">
-							<table>
-								<tbody>
-									<tr>
-										<td>경기날짜</td>
-										<td></td>
-										<td>${matchData.matchDate}</td>
-									</tr>
-									<tr class="basic-table-tr-spacer"></tr>
-									<tr>
-										<td>경기시간</td>
-										<td></td>
-										<td>${matchData.matchTime}</td>
-									</tr>
-								</tbody>
-							</table>
-						</div>
-						<div class="match-rally-container">
-							<table>
-								<tbody>
-									<tr>
-										<td>.</td>
-										<td></td>
-										<td>랠리 횟수</td>
-										<td></td>
-										<td>최대 공속도</td>
-									</tr>
-									<tr class="basic-table-tr-spacer"></tr>
-									<tr>
-										<td>최대</td>
-										<td></td>
-										<td>${matchData.maxRally}</td>
-										<td></td>
-										<td>${matchData.maxMaxBallSpeed.toFixed(2)}</td>
-									</tr>
-									<tr class="basic-table-tr-spacer"></tr>
-									<tr>
-										<td>평균</td>
-										<td></td>
-										<td>${matchData.avgRally.toFixed(2)}</td>
-										<td></td>
-										<td>${matchData.avgMaxBallSpeed.toFixed(2)}</td>
-									</tr>
-									<tr class="basic-table-tr-spacer"></tr>
-									<tr>
-										<td>최소</td>
-										<td></td>
-										<td>${matchData.minRally}</td>
-										<td></td>
-										<td>${matchData.minMaxBallSpeed.toFixed(2)}</td>
-									</tr>
-								</tbody>
-							</table>
-						</div>
+						${matchDateTimeHtml} ${matchRallyHtml}
 					</div>
 					<div class="divider"></div>
-					<div class="special-stats-container display-light18">
-						<table>
-							<tbody>
-								<tr class="display-light24">
-									<td>${matchData.leftPlayer}</td>
-									<td></td>
-									<td>.</td>
-									<td></td>
-									<td>${matchData.rightPlayer}</td>
-								</tr>
-								<tr class="special-table-tr-spacer"></tr>
-								<tr>
-									<td>${matchData.leftAttackType}</td>
-									<td></td>
-									<td>공격성향</td>
-									<td></td>
-									<td>${matchData.rightAttackType}</td>
-								</tr>
-								<tr class="special-table-tr-spacer"></tr>
-								<tr>
-									<td>${matchData.powerUpCnt1}</td>
-									<td></td>
-									<td>파워업 공격 횟수</td>
-									<td></td>
-									<td>${matchData.powerUpCnt2}</td>
-								</tr>
-								<tr class="special-table-tr-spacer"></tr>
-								<tr>
-									<td>${matchData.keyCnt1.toFixed(2)}</td>
-									<td></td>
-									<td>평균 키 입력 횟수</td>
-									<td></td>
-									<td>${matchData.keyCnt2.toFixed(2)}</td>
-								</tr>
-								<tr class="special-table-tr-spacer"></tr>
-								<tr>
-									<td>${matchData.leftAttackPos}</td>
-									<td></td>
-									<td>주요 공격 위치</td>
-									<td></td>
-									<td>${matchData.rightAttackPos}</td>
-								</tr>
-							</tbody>
-						</table>
-					</div>
+					${specialStatsHtml}
 					<div class="divider"></div>
 					<div class="graph-container">
-						<div class="score-trend-container">
-							<div class="score-trend-title display-light24">득점 추이</div>
-							<div class="score-trend-canvas-container">
-								<div
-									class="score-trend-canvas-text-container display-light10"
-								></div>
-								<canvas
-									class="score-trend-canvas-draw-container"
-									width="335"
-									height="360"
-								></canvas>
-							</div>
-							<div class="score-trend-player-name-container display-light16">
-								<div class="score-trend-player-name-wrapper">
-									<div class="score-player-name-margin-right">
-										${matchData.leftPlayer}
-									</div>
-									<div class="score-player-color-yellow"></div>
-								</div>
-								<div class="score-trend-player-name-wrapper">
-									<div class="score-player-name-margin-right">
-										${matchData.rightPlayer}
-									</div>
-									<div class="score-player-color-blue"></div>
-								</div>
-							</div>
-						</div>
-						<div class="score-position-container">
-							<div class="score-position-title display-light24">득점 위치</div>
-							<div class="score-position-player-name-container display-light16">
-								<div class="score-position-player-left-wrapper">
-									<div class="score-player-name-margin-right">
-										${matchData.leftPlayer}
-									</div>
-									<div class="score-player-color-yellow"></div>
-								</div>
-								<div class="score-position-player-right-wrapper">
-									<div class="score-player-color-blue"></div>
-									<div class="score-player-name-margin-left">
-										${matchData.rightPlayer}
-									</div>
-								</div>
-							</div>
-							<canvas class="score-position-canvas" width="280" height="360">
-							</canvas>
-						</div>
+						${scoreTrendHtml} ${scorePositionHtml}
 					</div>
 				</div>
 				<div class="event-click-match" style="margin-top: 4rem">
@@ -198,13 +55,13 @@ class DuelStatsPage {
 	mount(data) {
 		const matchData = DuelStatsData.getMountDuelStatsData(data);
 		// score-trend
-		GraphScore.appendScoresToYAxis(matchData.maxScore);
-		GraphScore.appendScoreTrendGraph(
+		DuelGraphStats.appendScoresToYAxis(matchData.maxScore);
+		DuelGraphStats.appendScoreTrendGraph(
 			matchData.leftScoreTrend,
 			matchData.rightScoreTrend
 		);
 		// score-position
-		GraphScore.appendScorePositionGraph(
+		DuelGraphStats.appendScorePositionGraph(
 			matchData.leftPosition,
 			matchData.rightPosition
 		);

--- a/FE/src/pages/DuelStatsPage.js
+++ b/FE/src/pages/DuelStatsPage.js
@@ -1,45 +1,18 @@
 import { changeUrl } from '../index.js';
 import BoldTitle from '../components/BoldTitle.js';
 import ButtonSmall from '../components/ButtonSmall.js';
-import {
-	graphScoreText,
-	getScoreTextPosition,
-	graphScoreTrend,
-	graphScorePosition
-} from '../components/GraphScore.js';
+import DuelStatsData from '../components/DuelStatsData.js';
+import GraphScore from '../components/GraphScore.js';
+// import
 
 const html = String.raw;
 
 class DuelStatsPage {
 	template(data) {
-		const attackTypeList = ['공격형', '방어형', '혼합형'];
-		const attackPosList = ['상단', '중단', '하단', '전체'];
-		/* Mock Data - api 가져오기 */
-		const leftPlayer = data ? data.player1.nickname : '플레이어1';
-		const rightPlayer = data ? data.player2.nickname : '플레이어2';
-		const leftScore = data ? data.player1.score : 0;
-		const rightScore = data ? data.player2.score : 0;
-		const matchDate = data ? data.date : '2021-03-17';
-		const matchTime = data ? data.play_time : '00:00:01';
-		const winPlayer =
-			leftScore > rightScore ? `${leftPlayer} WIN!` : `${rightPlayer} WIN!`;
-		const maxRally = data ? data.rally[0] : 0;
-		const maxMaxBallSpeed = data ? data.max_ball_speed[0] : 0;
-		const avgRally = data ? data.rally[1] : 0;
-		const avgMaxBallSpeed = data ? data.max_ball_speed[1] : 0;
-		const minRally = data ? data.rally[2] : 0;
-		const minMaxBallSpeed = data ? data.max_ball_speed[2] : 0;
-		const attackType1 = data ? data.player1.attack_type : 0;
-		const attackType2 = data ? data.player2.attack_type : 0;
-		const powerUpCnt1 = data ? data.player1.power_up_cnt : 0;
-		const powerUpCnt2 = data ? data.player2.power_up_cnt : 0;
-		const keyCnt1 = data ? data.player1.key_cnt : 0;
-		const keyCnt2 = data ? data.player2.key_cnt : 0;
-		const attackPos1 = data ? data.player1.attack_pos : 0;
-		const attackPos2 = data ? data.player2.attack_pos : 0;
+		const matchData = DuelStatsData.getDuelStatsData(data);
 
 		/* Components */
-		const titlComponent = new BoldTitle(winPlayer, 'pink');
+		const titlComponent = new BoldTitle(matchData.winPlayer, 'pink');
 		const nextButton = new ButtonSmall('다음');
 
 		return html`
@@ -47,13 +20,13 @@ class DuelStatsPage {
 				${titlComponent.template()}
 				<div class="medium-window-container">
 					<div class="score-board-container display-light28">
-						<div>${leftPlayer}</div>
+						<div>${matchData.leftPlayer}</div>
 						<ul class="score-board-wrapper pink_neon_10">
-							<li>${leftScore}</li>
+							<li>${matchData.leftScore}</li>
 							<li>:</li>
-							<li>${rightScore}</li>
+							<li>${matchData.rightScore}</li>
 						</ul>
-						<div>${rightPlayer}</div>
+						<div>${matchData.rightPlayer}</div>
 					</div>
 					<div class="divider"></div>
 					<div class="basic-stats-container display-light18">
@@ -63,13 +36,13 @@ class DuelStatsPage {
 									<tr>
 										<td>경기날짜</td>
 										<td></td>
-										<td>${matchDate}</td>
+										<td>${matchData.matchDate}</td>
 									</tr>
 									<tr class="basic-table-tr-spacer"></tr>
 									<tr>
 										<td>경기시간</td>
 										<td></td>
-										<td>${matchTime}</td>
+										<td>${matchData.matchTime}</td>
 									</tr>
 								</tbody>
 							</table>
@@ -88,25 +61,25 @@ class DuelStatsPage {
 									<tr>
 										<td>최대</td>
 										<td></td>
-										<td>${maxRally}</td>
+										<td>${matchData.maxRally}</td>
 										<td></td>
-										<td>${maxMaxBallSpeed.toFixed(2)}</td>
+										<td>${matchData.maxMaxBallSpeed.toFixed(2)}</td>
 									</tr>
 									<tr class="basic-table-tr-spacer"></tr>
 									<tr>
 										<td>평균</td>
 										<td></td>
-										<td>${avgRally.toFixed(2)}</td>
+										<td>${matchData.avgRally.toFixed(2)}</td>
 										<td></td>
-										<td>${avgMaxBallSpeed.toFixed(2)}</td>
+										<td>${matchData.avgMaxBallSpeed.toFixed(2)}</td>
 									</tr>
 									<tr class="basic-table-tr-spacer"></tr>
 									<tr>
 										<td>최소</td>
 										<td></td>
-										<td>${minRally}</td>
+										<td>${matchData.minRally}</td>
 										<td></td>
-										<td>${minMaxBallSpeed.toFixed(2)}</td>
+										<td>${matchData.minMaxBallSpeed.toFixed(2)}</td>
 									</tr>
 								</tbody>
 							</table>
@@ -117,43 +90,43 @@ class DuelStatsPage {
 						<table>
 							<tbody>
 								<tr class="display-light24">
-									<td>${leftPlayer}</td>
+									<td>${matchData.leftPlayer}</td>
 									<td></td>
 									<td>.</td>
 									<td></td>
-									<td>${rightPlayer}</td>
+									<td>${matchData.rightPlayer}</td>
 								</tr>
 								<tr class="special-table-tr-spacer"></tr>
 								<tr>
-									<td>${attackTypeList[attackType1]}</td>
+									<td>${matchData.leftAttackType}</td>
 									<td></td>
 									<td>공격성향</td>
 									<td></td>
-									<td>${attackTypeList[attackType2]}</td>
+									<td>${matchData.rightAttackType}</td>
 								</tr>
 								<tr class="special-table-tr-spacer"></tr>
 								<tr>
-									<td>${powerUpCnt1}</td>
+									<td>${matchData.powerUpCnt1}</td>
 									<td></td>
 									<td>파워업 공격 횟수</td>
 									<td></td>
-									<td>${powerUpCnt2}</td>
+									<td>${matchData.powerUpCnt2}</td>
 								</tr>
 								<tr class="special-table-tr-spacer"></tr>
 								<tr>
-									<td>${keyCnt1.toFixed(2)}</td>
+									<td>${matchData.keyCnt1.toFixed(2)}</td>
 									<td></td>
 									<td>평균 키 입력 횟수</td>
 									<td></td>
-									<td>${keyCnt2.toFixed(2)}</td>
+									<td>${matchData.keyCnt2.toFixed(2)}</td>
 								</tr>
 								<tr class="special-table-tr-spacer"></tr>
 								<tr>
-									<td>${attackPosList[attackPos1]}</td>
+									<td>${matchData.leftAttackPos}</td>
 									<td></td>
 									<td>주요 공격 위치</td>
 									<td></td>
-									<td>${attackPosList[attackPos2]}</td>
+									<td>${matchData.rightAttackPos}</td>
 								</tr>
 							</tbody>
 						</table>
@@ -175,13 +148,13 @@ class DuelStatsPage {
 							<div class="score-trend-player-name-container display-light16">
 								<div class="score-trend-player-name-wrapper">
 									<div class="score-player-name-margin-right">
-										${leftPlayer}
+										${matchData.leftPlayer}
 									</div>
 									<div class="score-player-color-yellow"></div>
 								</div>
 								<div class="score-trend-player-name-wrapper">
 									<div class="score-player-name-margin-right">
-										${rightPlayer}
+										${matchData.rightPlayer}
 									</div>
 									<div class="score-player-color-blue"></div>
 								</div>
@@ -192,14 +165,14 @@ class DuelStatsPage {
 							<div class="score-position-player-name-container display-light16">
 								<div class="score-position-player-left-wrapper">
 									<div class="score-player-name-margin-right">
-										${leftPlayer}
+										${matchData.leftPlayer}
 									</div>
 									<div class="score-player-color-yellow"></div>
 								</div>
 								<div class="score-position-player-right-wrapper">
 									<div class="score-player-color-blue"></div>
 									<div class="score-player-name-margin-left">
-										${rightPlayer}
+										${matchData.rightPlayer}
 									</div>
 								</div>
 							</div>
@@ -223,23 +196,18 @@ class DuelStatsPage {
 	}
 
 	mount(data) {
+		const matchData = DuelStatsData.getMountDuelStatsData(data);
 		// score-trend
-		const leftScoreTrend = data ? data.graph.player1.score_trend : [];
-		const rightScoreTrend = data ? data.graph.player2.score_trend : [];
-		const leftScore = data ? data.player1.score : 15;
-		const rightScore = data ? data.player2.score : 15;
-		const maxScore = leftScore >= rightScore ? leftScore : rightScore;
-		const scoreText = document.querySelector(
-			'.score-trend-canvas-text-container'
+		GraphScore.appendScoresToYAxis(matchData.maxScore);
+		GraphScore.appendScoreTrendGraph(
+			matchData.leftScoreTrend,
+			matchData.rightScoreTrend
 		);
-		scoreText.appendChild(graphScoreText(maxScore));
-		const position = getScoreTextPosition();
-		graphScoreTrend(leftScoreTrend, rightScoreTrend, position);
-
 		// score-position
-		const leftPosition = data ? data.graph.player1.score_pos : [];
-		const rightPosition = data ? data.graph.player2.score_pos : [];
-		graphScorePosition(leftPosition, rightPosition);
+		GraphScore.appendScorePositionGraph(
+			matchData.leftPosition,
+			matchData.rightPosition
+		);
 	}
 }
 

--- a/FE/src/pages/LoginPage.js
+++ b/FE/src/pages/LoginPage.js
@@ -46,7 +46,7 @@ class LoginPage {
 	addEventListeners() {
 		const loginButton = document.querySelector('.login-button');
 		loginButton.addEventListener('click', () => {
-			changeUrl('tournamentResult');
+			changeUrl('duelstats');
 		});
 
 		const signupLink = document.querySelector('.login-signup-link');

--- a/FE/src/pages/LoginPage.js
+++ b/FE/src/pages/LoginPage.js
@@ -56,7 +56,7 @@ class LoginPage {
 
 		const login42 = document.querySelector('.login-42');
 		login42.addEventListener('click', () => {
-			changeUrl('tournament');
+			changeUrl('tournamentResult');
 		});
 
 		const loginGuest = document.querySelector('.login-guest');


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

- 게임 결과 통계 페이지(DuelStatsPage) 리팩토링

## 🧑‍💻 PR 세부 내용

1. Data 선언 코드 줄이기
   - 기존 DuelStatsPage template()에 있었던 데이터 관련 선언들을 DuelStatsData.js -> getDuelStatsData(data) 함수로 받아 오도록 수정
   - DuelStatsPage mount()에 있었던 데이터 관련 선언들 또한 DuelStatsData.js -> getMountDuelStatsData(data) 함수로 받아 오도록 수정
2. DuelStatsPage template() 안의 Html 코드 컴포넌트로 분리
    - 컴포넌트 파일 DuelBasicStats.js / DuelSpecialStats.js / DuelGraphStats.js 안에 정적 메소드로 정의
3. DuelStatsPage mount() 안의 사용했던 컴포넌트 함수들 리팩토링
   - DuelGraphStats.js 안에 appendScoresToYAxis, appendScoreTrendGraph, appendScorePositionGraph 정적 메소드로 정의
## 📸 스크린샷
- 기존 200줄 이상의 template() 함수 코드를 컴포넌트로 분리 하여 스크린샷과 같이 수정
<img width="1000" alt="스크린샷 2024-03-24 오후 6 04 15" src="https://github.com/authenticity-house/ft_transcendence/assets/83465749/60daf315-0351-4309-b544-6eebeec5d7c4">

## 📚 관련 이슈
close #83
