### PR TITLE
[Hotfix] 로컬 1vs1 게임이 작동되지 않는 문제 해결

### DIFF
--- a/FE/src/pages/GameSettingPage.js
+++ b/FE/src/pages/GameSettingPage.js
@@ -15,7 +15,7 @@ class GameSettingPage {
 				ball: '#FFD164'
 			},
 			headcount: 2,
-			nickname: []
+			nickname: ['player1', 'player2']
 		};
 	}
 

--- a/GAME/match/ball.py
+++ b/GAME/match/ball.py
@@ -123,7 +123,7 @@ class Ball:
         return False
 
     def get_stat_data(self) -> dict[str, str | float]:
-        return {"status": "in", "x": self._x, "y": self._y}
+        return {"status": "in", "x": self._x, "y": self._y, "radius": Ball.BALL_RADIUS}
 
     @property
     def x(self) -> float:

--- a/GAME/session/session_manager.py
+++ b/GAME/session/session_manager.py
@@ -1,81 +1,40 @@
+from abc import ABCMeta, abstractmethod
+
 from match.match_manager import MatchManager
 from match.player import Player
 from match.ball import Ball
 from .bracket import Bracket
 
 
-class SessionManager:
-    def __init__(self, data):
+class ASessionManager(metaclass=ABCMeta):
+    def __init__(self, data, battle_mode: int):
+        self._battle_mode = battle_mode
         self._total_score = data.get("total_score", 15)
         self._level = data.get("level", 2)
         self._color = data.get("color", {"paddle": "#5AD7FF", "ball": "#FFD164"})
-        self._battle_mode = data.get("battle_mode", 1)
-        self._match_manager: MatchManager = None
-        self._summary_stat = []
-        self._latest_winner = ""
 
-        nickname = data.get("nickname", ["player1", "player2"])
-        headcount = data.get("headcount", len(nickname))
-        self._bracket: Bracket = Bracket(nickname, headcount)
+        self._match_manager: MatchManager = None
+
+    # 소켓에서 전송할 데이터 반환
+    @abstractmethod
+    def get_send_data(self, subtype: str):
+        pass
+
+    @abstractmethod
+    def get_match_nickname(self):
+        pass
+
+    @abstractmethod
+    def get_first_message(self):
+        pass
 
     def get_match_frame(self):
         yield from self._match_manager.get_match_frame()
 
-    # 소켓에서 전송할 데이터 반환
-    def get_send_data(self, subtype: str):
-        if subtype == "tournament_tree":
-            data = {
-                "battle_mode": self._battle_mode,
-                "winner": self._latest_winner,
-                "bracket": self._bracket.get_bracket(),
-            }
-            return subtype, "3-1 대진표", data
-
-        if subtype == "match_init_setting":
-            return subtype, "", self.initialize_match()
-
-        # if subtype == "match_run":
-        #     return
-        #     # return subtype, "4-4 게임 데이터 전송", self._match_manager.get_send_data()
-
-        if subtype == "match_end":
-            data = self._match_manager.get_match_stat()
-            self._summary_stat.append(data)
-
-            if self.battle_mode == 2:
-                # 이긴 사람에 대해 업데이트 필요함
-                self._latest_winner = self.get_winner_nickname(data)
-                self._bracket.set_winner_nickname(self._latest_winner)
-            return subtype, "5-1 매치 통계 정보 전송", data
-
-        if subtype == "next_match":
-            data = {
-                "battle_mode": self._battle_mode,
-                "winner": self._latest_winner,
-                "bracket": self._bracket.get_bracket(),
-            }
-
-            if self._bracket.is_end:
-                return "tournament_tree", "6-1 대진표", data, "game_over"
-
-            return "tournament_tree", "3-1 대진표", data
-
-        return "error", "not match subtype", {}
-
-    def get_winner_nickname(self, data) -> str:
-        player1, player2 = data["player1"], data["player2"]
-
-        if player1["score"] == self._total_score:
-            return player1["nickname"]
-
-        if player2["score"] == self._total_score:
-            return player2["nickname"]
-
-        return "error"
-
     def initialize_match(self):
         paddle_height, ball_speed, ball_accel_speed = self.get_level_info()
-        player1_nickname, player2_nickname = self._bracket.get_match_nickname()
+        print(self.get_match_nickname())
+        player1_nickname, player2_nickname = self.get_match_nickname()
 
         self._match_manager = MatchManager(
             total_score=self._total_score,
@@ -88,18 +47,10 @@ class SessionManager:
 
         return self.get_initial_settings()
 
-    # 매치 진행
-    def start_match(self):
-        pass
-
     def set_match_key_set(self, key_set):
         if self._match_manager is None:
             return
         self._match_manager.keys = set(key_set)
-
-    # 최종 게임 결과 반환
-    def get_summary_stat(self):
-        return self._summary_stat
 
     def get_level_info(self):
         """패들 길이, 공 속도, 공 가속도 반환"""
@@ -132,3 +83,95 @@ class SessionManager:
     @property
     def battle_mode(self) -> int:
         return self._battle_mode
+
+
+class TournamentManager(ASessionManager):
+    def __init__(self, data):
+        super().__init__(data, 2)
+        self._summary_stat = []
+        self._latest_winner = ""
+
+        nickname = data["nickname"]
+        headcount = data.get("headcount", len(nickname))
+        self._bracket: Bracket = Bracket(nickname, headcount)
+
+    # 소켓에서 전송할 데이터 반환
+    def get_send_data(self, subtype: str):
+        if subtype == "tournament_tree":
+            data = {
+                "battle_mode": self._battle_mode,
+                "winner": self._latest_winner,
+                "bracket": self._bracket.get_bracket(),
+            }
+            return subtype, "3-1 대진표", data
+
+        if subtype == "match_init_setting":
+            return subtype, "", self.initialize_match()
+
+        if subtype == "match_end":
+            data = self._match_manager.get_match_stat()
+            self._summary_stat.append(data)
+
+            # 이긴 사람에 대해 업데이트
+            self._latest_winner = self.get_winner_nickname(data)
+            self._bracket.set_winner_nickname(self._latest_winner)
+            return subtype, "5-1 매치 통계 정보 전송", data
+
+        if subtype == "next_match":
+            data = {
+                "battle_mode": self._battle_mode,
+                "winner": self._latest_winner,
+                "bracket": self._bracket.get_bracket(),
+            }
+
+            if self._bracket.is_end:
+                return "tournament_tree", "6-1 대진표", data, "game_over"
+
+            return "tournament_tree", "3-1 대진표", data
+
+        return "error", "not match subtype", {}
+
+    def get_winner_nickname(self, data) -> str:
+        player1, player2 = data["player1"], data["player2"]
+
+        if player1["score"] == self._total_score:
+            return player1["nickname"]
+
+        if player2["score"] == self._total_score:
+            return player2["nickname"]
+
+        return "error"
+
+    def get_match_nickname(self):
+        return self._bracket.get_match_nickname()
+
+    def get_first_message(self):
+        return self.get_send_data("tournament_tree")
+
+    # 최종 게임 결과 반환
+    def get_summary_stat(self):
+        return self._summary_stat
+
+
+class DuelManager(ASessionManager):
+    def __init__(self, data):
+        super().__init__(data, 1)
+
+        self._nickname = data.get("nickname", ["player1", "player2"])
+
+    # 소켓에서 전송할 데이터 반환
+    def get_send_data(self, subtype: str):
+        if subtype == "match_init_setting":
+            return subtype, "2-2", self.initialize_match()
+
+        if subtype == "match_end":
+            data = self._match_manager.get_match_stat()
+            return subtype, "4-1", data
+
+        return "error", "not match subtype", {}
+
+    def get_match_nickname(self):
+        return self._nickname
+
+    def get_first_message(self):
+        return self.get_send_data("match_init_setting")


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

로컬 1vs1 게임이 작동되지 않는 문제 해결
- 로컬 1vs1 시작할 때 전송되는 nickname 데이터 값 수정
- SessionManager를 1vs1과 토너먼트에 따라 분리

## 🧑‍💻 PR 세부 내용

### 1. nickname 정보를 전송할 때 규약에 맞도록 수정
- 이전에는 `nickname: []`을 전송하면 게임 서버에서 nickname 정보를 저장할 때 빈 값이 저장되면서 파싱 오류 발생
- `nickname: ['player1', 'player2']` 로 기본 값을 포함하도록 변경

### 2. ASessionManager, DuelManager, TournamentManager 구현
- 이전에 `SessionManager`에 구현되어있던 부분을 모두 분리
- 추상 클래스 `ASessionManager` 구현
  - 추상 클래스 사용을 위해 `abc` 모듈 import
  - 상속받는 자식 클래스에서 구현해야 하는 함수에는 `@abstractmethod`  데코레이터 사용 
- 1vs1을 위한 `DuelManager` 구현
- 토너먼트를 위한 `TournamentManager` 구현

### 3. 공 초기 데이터에 공 반지름 정보 포함하도록 수정
- 현재 매치 초기 정보 전송 시 공 반지름에 대한 정보가 존재하지 않음
- 이를 포함해서 전송하도록 수정

## 📸 스크린샷

<img width="300" alt="Screen Shot 2024-03-24 at 7 23 15 PM" src="https://github.com/authenticity-house/ft_transcendence/assets/44529556/c7ea2d87-5d2b-49ac-a222-131ae40d82fa">

## 📚 관련 이슈

- close #86