### PR TITLE
[Feat] 토너먼트 대진표 페이지 - 데이터 받아서 대진표 띄우기

### DIFF
--- a/FE/src/components/TournamentBracket.js
+++ b/FE/src/components/TournamentBracket.js
@@ -1,10 +1,13 @@
 const html = String.raw;
 
 function bracketTemplate(bracketInfo) {
-	const playerCount = bracketInfo.length;
+	let playerCount = 0;
 	let userWrappers = '';
 	for (let i = 0; i < bracketInfo.length; i += 1) {
-		userWrappers += `<div class="user-wrapper"><p>${bracketInfo[i]}</p></div>`;
+		for (let j = 0; j < bracketInfo[i].length; j += 1) {
+			userWrappers += `<div class="user-wrapper"><p>${bracketInfo[i][j]}</p></div>`;
+			playerCount += 1;
+		}
 	}
 	if (playerCount <= 4) {
 		return html`
@@ -48,30 +51,27 @@ function getUserPosition() {
 	return { position, halfHeight };
 }
 
-function addUserBracket(
-	position,
-	halfHeight,
-	child,
-	depth,
-	bracketInfo,
-	winPlayer
-) {
-	for (let i = 0; i < position.length; i += 1) {
-		const topPosition = position[i] - halfHeight;
-		const userWrapper = document.createElement('div');
-		userWrapper.style.top = `${topPosition}px`;
-		userWrapper.style.left = '0';
-		userWrapper.classList.add('user-wrapper-position');
+function addUserBracket(position, halfHeight, child, bracketInfo, winPlayer) {
+	let positionIndex = 0;
+	for (let i = 0; i < bracketInfo.length; i += 1) {
+		for (let j = 0; j < bracketInfo[i].length; j += 1) {
+			const topPosition = position[positionIndex] - halfHeight;
+			positionIndex += 1;
+			const userWrapper = document.createElement('div');
+			userWrapper.style.top = `${topPosition}px`;
+			userWrapper.style.left = '0';
+			userWrapper.classList.add('user-wrapper-position');
 
-		const userWrapperText = bracketInfo[depth][i];
-		const textSpan = document.createElement('span');
-		textSpan.textContent = userWrapperText;
-		if (userWrapperText === 'PONG !')
-			userWrapper.classList.add('pong-animation');
-		if (userWrapperText === winPlayer)
-			textSpan.classList.add('win-player-animation');
-		userWrapper.appendChild(textSpan);
-		child.appendChild(userWrapper);
+			const userWrapperText = bracketInfo[i][j];
+			const textSpan = document.createElement('span');
+			textSpan.textContent = userWrapperText;
+			if (userWrapperText === 'PONG !')
+				userWrapper.classList.add('pong-animation');
+			if (userWrapperText === winPlayer)
+				textSpan.classList.add('win-player-animation');
+			userWrapper.appendChild(textSpan);
+			child.appendChild(userWrapper);
+		}
 	}
 }
 

--- a/FE/src/pages/TournamentPage.js
+++ b/FE/src/pages/TournamentPage.js
@@ -62,20 +62,9 @@ class TournamentPage {
 		const next = document.querySelector('.event-click-match');
 		next.addEventListener('click', () => {
 			if (this.data.gameOver === true) {
-				const message = JSON.stringify({
-					type: 'game_over',
-					subtype: 'summary',
-					message: 'go!'
-				});
-				this.data.Gamewebsocket.send(message);
+				this.data.Gamewebsocket.sendGameOver();
 			} else {
-				const message = JSON.stringify({
-					type: 'game',
-					subtype: 'match_init_setting',
-					message: 'go!',
-					data: {}
-				});
-				this.data.Gamewebsocket.send(message);
+				this.data.Gamewebsocket.sendGameMatchInitSetting();
 			}
 		});
 	}

--- a/FE/src/pages/TournamentPage.js
+++ b/FE/src/pages/TournamentPage.js
@@ -12,14 +12,9 @@ const html = String.raw;
 class TournamentPage {
 	template(data) {
 		this.data = data;
-		// console.log(data);
-
 		const titlComponent = new BoldTitle('대진표', 'yellow');
 		const nextButton = new ButtonSmall('다음');
-
-		/* <MOCK DATA> bracketInfo = data.depth */
 		const bracketInfo = this.data.bracket;
-
 		const openBracket = bracketTemplate(bracketInfo[0]);
 
 		return html`
@@ -35,25 +30,10 @@ class TournamentPage {
 		`;
 	}
 
-	mount() {
-		/* <MOCK DATA> bracketInfo = data.depth (data.depth[0] 빼고 다 활용) */
-		// data.depth[1], data.dept[2]
-		const bracketInfo = [
-			[
-				'wonyang',
-				'jeongmin',
-				'joyoo',
-				'jihylim',
-				'player5',
-				'player6',
-				'player7'
-			],
-			['wonyang', 'PONG !', '', ''],
-			['', ''],
-			['']
-		];
-		const winPlayer = 'wonyang';
-		/* */
+	mount(data) {
+		this.data = data;
+		const bracketInfo = this.data.bracket;
+		const winPlayer = this.data.winner;
 		const { position, halfHeight } = getUserPosition();
 		const tournamentBracket = document.querySelector('.tournament-bracket');
 		const tournamentBracketChild = tournamentBracket.children;
@@ -68,8 +48,7 @@ class TournamentPage {
 					position,
 					halfHeight,
 					child,
-					depth,
-					bracketInfo,
+					bracketInfo[depth],
 					winPlayer
 				);
 				depth += 1;
@@ -83,9 +62,20 @@ class TournamentPage {
 		const next = document.querySelector('.event-click-match');
 		next.addEventListener('click', () => {
 			if (this.data.gameOver === true) {
-				this.data.Gamewebsocket.sendGameOver();
+				const message = JSON.stringify({
+					type: 'game_over',
+					subtype: 'summary',
+					message: 'go!'
+				});
+				this.data.Gamewebsocket.send(message);
 			} else {
-				this.data.Gamewebsocket.sendGameMatchInitSetting();
+				const message = JSON.stringify({
+					type: 'game',
+					subtype: 'match_init_setting',
+					message: 'go!',
+					data: {}
+				});
+				this.data.Gamewebsocket.send(message);
 			}
 		});
 	}


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 토너먼트 대진표 페이지 - 데이터 받아서 대진표 띄우기 

## 🧑‍💻 PR 세부 내용
- 웹소켓으로 토너먼트 대진표 데이터를 받습니다.
- 대진표 데이터를 파싱하여 알맞은 대진표 위치에 넣습니다.

## 📸 스크린샷

스크린샷을 첨부해주세요.

## 📚 관련 이슈

- close #89