### PR TITLE
[Hotfix] 토너먼트 모드 2번째 판부터 Ready가 보이지 않는 오류 수정

### DIFF
--- a/FE/src/Gamewebsocket.js
+++ b/FE/src/Gamewebsocket.js
@@ -275,6 +275,7 @@ export class Gamewebsocket {
 						} else {
 							message.data.Gamewebsocket = this;
 						}
+						this.frame = 0;
 						changeUrlData('duelstats', message.data);
 					} else if (message.subtype === 'error') {
 						console.log(`server: ${message.message}`);


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

토너먼트 모드 2번째 판부터 Ready가 보이지 않는 오류 수정

## 🧑‍💻 PR 세부 내용

토너먼트 모드 2번째 판부터 Ready가 보이지 않는 오류 수정

## 📸 스크린샷

음슴!

## 📚 관련 이슈

음슴!
