### PR TITLE
[Hotfix] 게임 종료 판단 오류 및 공 속도 수정

### DIFF
--- a/GAME/session/bracket.py
+++ b/GAME/session/bracket.py
@@ -113,4 +113,7 @@ class Bracket:
 
     @property
     def is_end(self):
-        return self._bracket[-1][0][0] not in [Bracket.MATCH_NOT_START, Bracket.MATCH_PLAYING]
+        return (
+            len(self._bracket) == self._play_match[0] + 1
+            and self._bracket[-1][-1][-1] != Bracket.MATCH_PLAYING
+        )

--- a/GAME/session/session_manager.py
+++ b/GAME/session/session_manager.py
@@ -55,11 +55,11 @@ class ASessionManager(metaclass=ABCMeta):
     def get_level_info(self):
         """패들 길이, 공 속도, 공 가속도 반환"""
         if self._level == 1:
-            return 0.5, 0.45, 0.003
+            return 0.5, 0.045, 0.003
         if self._level == 2:
-            return 0.4, 0.5, 0.004
+            return 0.4, 0.05, 0.004
 
-        return 0.3, 0.55, 0.004
+        return 0.3, 0.055, 0.004
 
     def get_initial_settings(self):
         ball: Ball = self._match_manager.ball

--- a/GAME/session/session_manager.py
+++ b/GAME/session/session_manager.py
@@ -55,11 +55,11 @@ class ASessionManager(metaclass=ABCMeta):
     def get_level_info(self):
         """패들 길이, 공 속도, 공 가속도 반환"""
         if self._level == 1:
-            return 0.5, 0.04, 0.003
+            return 0.5, 0.45, 0.003
         if self._level == 2:
-            return 0.4, 0.04, 0.004
+            return 0.4, 0.5, 0.004
 
-        return 0.3, 0.05, 0.004
+        return 0.3, 0.55, 0.004
 
     def get_initial_settings(self):
         ball: Ball = self._match_manager.ball


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

- 토너먼트에서 게임 종료 판단 로직 수정
- 레벨에 따른 공 속도 수정

## 🧑‍💻 PR 세부 내용

### 승자 업데이트 시 게임 종료 확인 
- 이전에는 빈 문자열인 경우, 게임을 진행하지 않았다고 판단했으나 닉네임이 빈 값이 들어오는 경우 처리가 제대로 되지 않아 인덱스 에러 발생
- 빈 문자열이 닉네임으로 들어왔을 때도 확인하기 위해 로직 수정

### 닉네임에 따른 공 속도 변경 
- 매치 랠리마다 기본 속도로 시작한 후 패들에 공이 닿았을 때 레벨에 맞는 속도로 변경
- 이때 기본 속도와 레벨 속도가 동일해서 변경되지 않는 오류 수정

## 📸 스크린샷

<img width="400" alt="스크린샷 2024-03-26 오후 9 52 42" src="https://github.com/authenticity-house/ft_transcendence/assets/44529556/edab0381-74fb-48a4-b07b-29425e143eba">


## 📚 관련 이슈

- close #90
