### PR TITLE
[Feat] 토너먼트 경기 결과 요약 페이지 데이터 띄우기

### DIFF
--- a/FE/public/css/styles.css
+++ b/FE/public/css/styles.css
@@ -72,7 +72,7 @@ button {
 	color: #fff;
 }
 
-button:hover:not(.button-back-arrow-box):not(.duel-detail-button) {
+button:hover:not(.button-back-arrow-box):not(.duel-toggle-button) {
 	background-color: #fff;
 	color: #141343;
 	cursor: pointer;
@@ -861,7 +861,7 @@ td {
 	display: flex;
 	justify-content: space-between;
 	width: 100%;
-	min-height: 45rem;
+	height: 45rem;
 }
 
 /* Graph - ScoreTrend */
@@ -968,7 +968,7 @@ td {
 	justify-content: space-between;
 	align-items: center;
 	width: 28rem;
-	margin-bottom: 1rem;
+	height: 3rem;
 }
 
 .score-position-player-left-wrapper {
@@ -992,7 +992,7 @@ td {
 	display: flex;
 	flex-direction: column;
 	width: 78rem;
-	height: 60rem;
+	height: 56rem;
 	overflow: scroll;
 }
 
@@ -1000,7 +1000,9 @@ td {
 	display: flex;
 	flex-direction: column;
 	width: 100%;
-	min-height: 18rem;
+	/* min-height: 18rem */
+	/* min-height: 18rem;
+	max-height: 55rem; */
 	border-radius: 3rem;
 	border: 0.4rem solid #ffffff;
 	padding: 2rem;
@@ -1013,6 +1015,7 @@ td {
 	width: 100%;
 	height: 9rem;
 	padding: 0 2rem;
+	margin-bottom: 2rem;
 }
 
 .duel-user-container {
@@ -1070,29 +1073,41 @@ td {
 	justify-content: center;
 	align-items: end;
 	width: 100%;
-	height: 100%;
+	height: 2.5rem;
 }
 
 .duel-date-time-wrapper {
 	display: flex;
 	align-items: center;
-	padding: 0 5rem;
 }
 
 .duel-date-time-title {
 	width: 7.2rem;
 	margin-right: 2rem;
+	margin-left: 5rem;
 }
 
 .duel-date-time-data {
-	width: 11rem;
+	width: 15rem;
 }
 
-.duel-detail-button {
+.duel-toggle-button {
 	border: none;
 	position: absolute;
 	width: 6rem;
 	height: 5rem;
+	top: 12rem;
 	right: 5.5rem;
-	bottom: 0.5rem;
+}
+
+.duel-button-roate {
+	transform: rotate(180deg);
+}
+
+.duel-toggle-container {
+	width: 100%;
+}
+
+.duel-toggle-hidden {
+	display: none;
 }

--- a/FE/src/components/DuelGraphStats.js
+++ b/FE/src/components/DuelGraphStats.js
@@ -35,6 +35,7 @@ class DuelGraphStats {
 		return html`
 			<div class="score-position-container">
 				<div class="score-position-title display-light24">득점 위치</div>
+				<canvas class="score-position-canvas" width="280" height="356"></canvas>
 				<div class="score-position-player-name-container display-light16">
 					<div class="score-position-player-left-wrapper">
 						<div class="score-player-name-margin-right">
@@ -49,15 +50,14 @@ class DuelGraphStats {
 						</div>
 					</div>
 				</div>
-				<canvas class="score-position-canvas" width="280" height="360"></canvas>
 			</div>
 		`;
 	}
 
-	static appendScoresToYAxis(maxScore) {
-		const scoreText = document.querySelector(
-			'.score-trend-canvas-text-container'
-		);
+	static appendScoresToYAxis(maxScore, graphContainer) {
+		const scoreText = graphContainer
+			? graphContainer.querySelector('.score-trend-canvas-text-container')
+			: document.querySelector('.score-trend-canvas-text-container');
 
 		let scoreTextWrappers = '';
 		for (let score = maxScore; score >= 0; score -= 1) {
@@ -70,18 +70,18 @@ class DuelGraphStats {
 		scoreText.appendChild(fragment);
 	}
 
-	static getScoreTextPosition() {
-		const scoreParent = document.querySelector(
-			'.score-trend-canvas-text-container'
-		);
+	static getScoreTextPosition(graphContainer) {
+		const scoreParent = graphContainer
+			? graphContainer.querySelector('.score-trend-canvas-text-container')
+			: document.querySelector('.score-trend-canvas-text-container');
 		const scoreParentRect = scoreParent.getBoundingClientRect();
 		const parentY = scoreParentRect.y;
 		const position = [];
 
 		let halfHeight;
-		const scoreTextWrappers = document.querySelectorAll(
-			'.score-trend-canvas-text-wrapper'
-		);
+		const scoreTextWrappers = graphContainer
+			? graphContainer.querySelectorAll('.score-trend-canvas-text-wrapper')
+			: document.querySelectorAll('.score-trend-canvas-text-wrapper');
 		scoreTextWrappers.forEach((child) => {
 			const childRect = child.getBoundingClientRect();
 			halfHeight = childRect.height / 2;
@@ -113,9 +113,15 @@ class DuelGraphStats {
 		ctx.closePath();
 	}
 
-	static appendScoreTrendGraph(leftScoreTrend, rightScoreTrend) {
-		const position = this.getScoreTextPosition();
-		const canvas = document.querySelector('.score-trend-canvas-draw-container');
+	static appendScoreTrendGraph(
+		leftScoreTrend,
+		rightScoreTrend,
+		graphContainer
+	) {
+		const position = this.getScoreTextPosition(graphContainer);
+		const canvas = graphContainer
+			? graphContainer.querySelector('.score-trend-canvas-draw-container')
+			: document.querySelector('.score-trend-canvas-draw-container');
 		const widthCount = leftScoreTrend.length + 1;
 		const widthDivide = canvas.width / widthCount;
 
@@ -152,8 +158,10 @@ class DuelGraphStats {
 		ctx.closePath();
 	}
 
-	static appendScorePositionGraph(leftPosition, rightPosition) {
-		const canvas = document.querySelector('.score-position-canvas');
+	static appendScorePositionGraph(leftPosition, rightPosition, graphContainer) {
+		const canvas = graphContainer
+			? graphContainer.querySelector('.score-position-canvas')
+			: document.querySelector('.score-position-canvas');
 		const ctx = canvas.getContext('2d');
 		const canvasHeight = canvas.height;
 		const canvasWidth = canvas.width;

--- a/FE/src/components/DuelReport.js
+++ b/FE/src/components/DuelReport.js
@@ -1,47 +1,71 @@
 const html = String.raw;
 
-function duelResultElement() {
+function duelResultElement(data) {
 	return html`
 		<div class="duel-user-container justify-content-start">
 			<div class="user-image-container"></div>
 			<div class="user-blank-container"></div>
-			<div class="user-nickname-container">hello</div>
+			<div class="user-nickname-container">${data.leftPlayer}</div>
 		</div>
 		<div class="duel-score-container pink_neon_10">
-			<div class="duel-score-wrapper">2</div>
+			<div class="duel-score-wrapper">${data.leftScore}</div>
 			<div class="duel-score-wrapper">:</div>
-			<div class="duel-score-wrapper">2</div>
+			<div class="duel-score-wrapper">${data.rightScore}</div>
 		</div>
 		<div class="duel-user-container justify-content-end">
-			<div class="user-nickname-container justify-content-end">hello</div>
+			<div class="user-nickname-container justify-content-end">
+				${data.rightPlayer}
+			</div>
 			<div class="user-blank-container"></div>
 			<div class="user-image-container"></div>
 		</div>
 	`;
 }
 
-function duelDateTimeElement() {
+function duelDateTimeElement(data) {
 	return html`
 		<div class="duel-date-time-wrapper">
 			<div class="duel-date-time-title">경기 날짜</div>
-			<div class="duel-date-time-data">2024.04.04</div>
+			<div class="duel-date-time-data">${data.matchDate}</div>
 		</div>
 		<div class="duel-date-time-wrapper">
 			<div class="duel-date-time-title">경기 시간</div>
-			<div class="duel-date-time-data">00:00:00</div>
+			<div class="duel-date-time-data">${data.matchTime}</div>
 		</div>
 	`;
 }
 
-function duelCollapseElement() {
-	return html``;
+function duelCollapseElement(
+	matchRallyHtml,
+	specialStatsHtml,
+	scoreTrendHtml,
+	scorePositionHtml
+) {
+	return html`
+		<div class="divider"></div>
+		<div class="basic-stats-container display-light18">${matchRallyHtml}</div>
+		<div class="divider"></div>
+		${specialStatsHtml}
+		<div class="divider"></div>
+		<div class="graph-container">${scoreTrendHtml} ${scorePositionHtml}</div>
+	`;
 }
 
-function duelReportWrapper(data) {
-	/* MOCK DATA */
+function duelReportWrapper(
+	data,
+	matchRallyHtml,
+	specialStatsHtml,
+	scoreTrendHtml,
+	scorePositionHtml
+) {
 	const resultElement = duelResultElement(data);
 	const dataTimeElement = duelDateTimeElement(data);
-	const collapseElement = duelCollapseElement(data);
+	const collapseElement = duelCollapseElement(
+		matchRallyHtml,
+		specialStatsHtml,
+		scoreTrendHtml,
+		scorePositionHtml
+	);
 
 	return html`
 		<div class="duel-report-wrapper">
@@ -49,18 +73,14 @@ function duelReportWrapper(data) {
 			<div class="duel-date-time-container display-light18">
 				${dataTimeElement}
 			</div>
-			<button
-				class="duel-detail-button"
-				data-toggle="collapse"
-				data-target=".duel-collapse-container"
-			>
+			<button class="duel-toggle-button">
 				<img
 					src="image/duel-detail-button.svg"
 					alt="back"
 					style="width: 4rem, color:white"
 				/>
 			</button>
-			<div class="duel-collapse-container">${collapseElement}</div>
+			<div class="duel-toggle-container">${collapseElement}</div>
 		</div>
 	`;
 }

--- a/FE/src/pages/LoginPage.js
+++ b/FE/src/pages/LoginPage.js
@@ -46,7 +46,7 @@ class LoginPage {
 	addEventListeners() {
 		const loginButton = document.querySelector('.login-button');
 		loginButton.addEventListener('click', () => {
-			changeUrl('duelstats');
+			console.log('login42');
 		});
 
 		const signupLink = document.querySelector('.login-signup-link');
@@ -56,7 +56,7 @@ class LoginPage {
 
 		const login42 = document.querySelector('.login-42');
 		login42.addEventListener('click', () => {
-			changeUrl('tournamentResult');
+			console.log('login42');
 		});
 
 		const loginGuest = document.querySelector('.login-guest');

--- a/FE/src/pages/TournamentResultPage.js
+++ b/FE/src/pages/TournamentResultPage.js
@@ -2,19 +2,35 @@ import { changeUrl } from '../index.js';
 import BoldTitle from '../components/BoldTitle.js';
 import ButtonSmall from '../components/ButtonSmall.js';
 import { duelReportWrapper } from '../components/DuelReport.js';
+import DuelStatsData from '../components/DuelStatsData.js';
+import DuelBasicStats from '../components/DuelBasicStats.js';
+import DuelSpecialStats from '../components/DuelSpecialStats.js';
+import DuelGraphStats from '../components/DuelGraphStats.js';
 
 const html = String.raw;
 
 class TournamentResultPage {
 	template(data) {
 		this.data = data;
+
 		const titlComponent = new BoldTitle('게임 결과', 'yellow');
 		const exitButton = new ButtonSmall('나가기');
 		let duelReports = '';
-		/* MOCK DATA */
-		const mockData = [0, 1, 2, 3, 4];
+		// console.log('한 묶음 데이터!');
 		for (let i = 0; i < data.length; i += 1) {
-			duelReports += duelReportWrapper(mockData[i]);
+			const resultData = DuelStatsData.getDuelStatsData(data[i]);
+			const matchRallyHtml = DuelBasicStats.getMatchRallyHTML(resultData);
+			const specialStatsHtml = DuelSpecialStats.getSpecialStatsHTML(resultData);
+			const scoreTrendHtml = DuelGraphStats.getScoreTrendHTML(resultData);
+			const scorePositionHtml = DuelGraphStats.getScorePositionHTML(resultData);
+
+			duelReports += duelReportWrapper(
+				resultData,
+				matchRallyHtml,
+				specialStatsHtml,
+				scoreTrendHtml,
+				scorePositionHtml
+			);
 		}
 
 		return html`
@@ -28,7 +44,49 @@ class TournamentResultPage {
 		`;
 	}
 
+	mount(data) {
+		let i = 0;
+		const graphContainers = document.querySelectorAll('.graph-container');
+		graphContainers.forEach((graphContainer) => {
+			const matchData = DuelStatsData.getMountDuelStatsData(data[i]);
+			// score-trend
+			DuelGraphStats.appendScoresToYAxis(matchData.maxScore, graphContainer);
+			DuelGraphStats.appendScoreTrendGraph(
+				matchData.leftScoreTrend,
+				matchData.rightScoreTrend,
+				graphContainer
+			);
+			// score-position
+			DuelGraphStats.appendScorePositionGraph(
+				matchData.leftPosition,
+				matchData.rightPosition,
+				graphContainer
+			);
+			i += 1;
+		});
+
+		const toggleConatiners = document.querySelectorAll(
+			'.duel-toggle-container'
+		);
+		toggleConatiners.forEach((toggleContainer) => {
+			toggleContainer.classList.toggle('duel-toggle-hidden');
+		});
+	}
+
 	addEventListeners() {
+		const toggleButtons = document.querySelectorAll('.duel-toggle-button');
+		toggleButtons.forEach((button) => {
+			button.addEventListener('click', () => {
+				const parentWrapper = button.closest('.duel-report-wrapper');
+				const toggleContent = parentWrapper.querySelector(
+					'.duel-toggle-container'
+				);
+				toggleContent.classList.toggle('duel-toggle-hidden');
+
+				button.querySelector('img').classList.toggle('duel-button-roate');
+			});
+		});
+
 		const exit = document.querySelector('.exit-button');
 		exit.addEventListener('click', () => {
 			this.data.Gamewebsocket.sendGameDisconnect();


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

- 토너먼트 경기 결과 요약 페이지 데이터 띄우기

## 🧑‍💻 PR 세부 내용
- 웹소켓으로 받아 온 데이터를 활용하여 경기 결과 요약 페이지를 만들기
  - 이전에 DuelStatsPage에서 분리 했던 데이터 컴포넌트를 재사용 하기
  - `.toggle()` 이용하여 상세 페이지 보이기 + 버튼 클릭 시, 버튼 이미지 바꾸기
    ```js
    addEventListeners() {
		const toggleButtons = document.querySelectorAll('.duel-toggle-button');
		toggleButtons.forEach((button) => {
			button.addEventListener('click', () => {
				const parentWrapper = button.closest('.duel-report-wrapper');
				const toggleContent = parentWrapper.querySelector(
					'.duel-toggle-container'
				);
				toggleContent.classList.toggle('duel-toggle-hidden'); /* 상세 페이지 보이기 or 감추기 */

				button.querySelector('img').classList.toggle('duel-button-roate'); /* 버튼 이미지 바꾸기 */
			});
		});
    ```
## 📸 스크린샷

https://github.com/authenticity-house/ft_transcendence/assets/83465749/4fdc80c2-85e5-4e2d-96b6-87dcbd35ca5b


## 📚 관련 이슈
close #77