### PR TITLE
[Feat] 토너먼트 대진표 페이지 - 우승자 UI 띄우기

### DIFF
--- a/FE/public/css/font.css
+++ b/FE/public/css/font.css
@@ -29,6 +29,15 @@
 	letter-spacing: 0.6rem;
 }
 
+.display-medium56 {
+	font-family: 'GongGothicMedium';
+	font-size: 5.6rem;
+	font-weight: normal;
+	font-style: normal;
+	line-height: normal;
+	letter-spacing: 0.56rem;
+}
+
 .display-medium52 {
 	font-family: 'GongGothicMedium';
 	font-size: 5.2rem;
@@ -54,6 +63,15 @@
 	font-style: normal;
 	line-height: normal;
 	letter-spacing: 0.44rem;
+}
+
+.display-medium36 {
+	font-family: 'GongGothicMedium';
+	font-size: 3.6rem;
+	font-weight: normal;
+	font-style: normal;
+	line-height: normal;
+	letter-spacing: 0.36rem;
 }
 
 .display-medium20 {

--- a/FE/public/css/styles.css
+++ b/FE/public/css/styles.css
@@ -805,6 +805,21 @@ td {
 	border-top: 0.3rem dotted #ffffff;
 }
 
+.replace-title-container {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	height: 13rem;
+	margin-top: 1rem;
+	margin-bottom: 1.5rem;
+}
+
+.champion-wrapper {
+	margin-bottom: 1.5rem;
+}
+
 /* GamePage.js */
 .game-header {
 	display: flex;

--- a/FE/src/components/TournamentBracket.js
+++ b/FE/src/components/TournamentBracket.js
@@ -5,7 +5,9 @@ function bracketTemplate(bracketInfo) {
 	let userWrappers = '';
 	for (let i = 0; i < bracketInfo.length; i += 1) {
 		for (let j = 0; j < bracketInfo[i].length; j += 1) {
-			userWrappers += `<div class="user-wrapper"><p>${bracketInfo[i][j]}</p></div>`;
+			userWrappers += `<div class="user-wrapper">
+				<p>${bracketInfo[i][j]}</p>
+				</div>`;
 			playerCount += 1;
 		}
 	}
@@ -63,13 +65,14 @@ function addUserBracket(position, halfHeight, child, bracketInfo, winPlayer) {
 			userWrapper.classList.add('user-wrapper-position');
 
 			const userWrapperText = bracketInfo[i][j];
-			const textSpan = document.createElement('span');
-			textSpan.textContent = userWrapperText;
+			const textP = document.createElement('p');
+
+			textP.textContent = userWrapperText;
 			if (userWrapperText === 'PONG !')
 				userWrapper.classList.add('pong-animation');
 			if (userWrapperText === winPlayer)
-				textSpan.classList.add('win-player-animation');
-			userWrapper.appendChild(textSpan);
+				textP.classList.add('win-player-animation');
+			userWrapper.appendChild(textP);
 			child.appendChild(userWrapper);
 		}
 	}
@@ -115,4 +118,29 @@ function addWireBracket(position, child, depth) {
 	position.splice(0, position.length, ...newPosition);
 }
 
-export { bracketTemplate, addUserBracket, addWireBracket, getUserPosition };
+function replaceTitle(className, winPlayer) {
+	const replaceElement = html`
+		<div class="replace-title-container">
+			<div class="champion-wrapper blue_neon_10 display-medium36">
+				<span>CHAMPION</span>
+			</div>
+			<div class="nickname-wrapper pink_neon_10 display-medium56">
+				‘${winPlayer}’
+			</div>
+		</div>
+	`;
+	const fragment = document
+		.createRange()
+		.createContextualFragment(replaceElement);
+	const existingElement = document.querySelector('.bold-title');
+	const parentElement = existingElement.parentNode;
+	parentElement.replaceChild(fragment, existingElement);
+}
+
+export {
+	bracketTemplate,
+	addUserBracket,
+	addWireBracket,
+	getUserPosition,
+	replaceTitle
+};

--- a/FE/src/pages/TournamentPage.js
+++ b/FE/src/pages/TournamentPage.js
@@ -4,7 +4,8 @@ import {
 	bracketTemplate,
 	addUserBracket,
 	addWireBracket,
-	getUserPosition
+	getUserPosition,
+	replaceTitle
 } from '../components/TournamentBracket.js';
 
 const html = String.raw;
@@ -40,6 +41,12 @@ class TournamentPage {
 		let depth = 0;
 		for (const child of tournamentBracketChild) {
 			if (depth === 0) {
+				const userNickName = child.getElementsByTagName('p');
+				for (let i = 0; i < userNickName.length; i += 1) {
+					if (userNickName[i].innerText === winPlayer) {
+						userNickName[i].classList.add('win-player-animation');
+					}
+				}
 				depth += 1;
 				continue;
 			}
@@ -54,6 +61,20 @@ class TournamentPage {
 				depth += 1;
 			} else if (child.classList.contains('wire-container')) {
 				addWireBracket(position, child, depth);
+			}
+		}
+
+		// tournament ending
+		const textElementAll = document.getElementsByTagName('p');
+		const lastBracketText = textElementAll[textElementAll.length - 1].innerText;
+		if (!(lastBracketText === '' || lastBracketText === 'PONG !')) {
+			// title change
+			replaceTitle('.bold-title', winPlayer);
+			// pong animation winPlayer
+			for (let i = 0; i < textElementAll.length; i += 1) {
+				if (textElementAll[i].innerText === winPlayer) {
+					textElementAll[i].parentNode.classList.add('pong-animation');
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

- 토너먼트 대진표 페이지 - 우승자 UI 띄우기

## 🧑‍💻 PR 세부 내용

- 토너먼트 대진표 페이지에서 마지막 우승자가 확정되었을 때의 UI 를 다르게 설정합니다.
   - 타이틀 : '대진표' -> CHAMPION '우승자'
   - 대진표 애니메이션 : 우승자 닉네임있는 곳 강조
 ### 구현 방식
- TournamentPage의 mount() 함수에서 마지막 우승자가 나타나면, 효과를 띄우게끔 코드 설정
```js
// tournament ending
const textElementAll = document.getElementsByTagName('p');
const lastBracketText = textElementAll[textElementAll.length - 1].innerText;
if (!(lastBracketText === '' || lastBracketText === 'PONG !')) {
	// title change
	replaceTitle('.bold-title', winPlayer);
	// pong animation winPlayer
	for (let i = 0; i < textElementAll.length; i += 1) {
		if (textElementAll[i].innerText === winPlayer) {
			textElementAll[i].parentNode.classList.add('pong-animation');
		}
	}
}
```
## 📸 스크린샷

https://github.com/authenticity-house/ft_transcendence/assets/83465749/215ab706-2b0c-404e-9b68-d1842bacf4ac


## 📚 관련 이슈
close #105