### PR TITLE
[Feat]  스크롤바 추가, 새로 고침 시 홈페이지로 링크 변경, history 로직 약간 수정 등

### DIFF
--- a/FE/public/css/styles.css
+++ b/FE/public/css/styles.css
@@ -17,6 +17,7 @@ body {
 	line-height: 1.6;
 	color: #ffffff;
 	background: var(--background, #141343);
+	overflow-x: hidden;
 }
 
 *,
@@ -79,7 +80,18 @@ button:hover:not(.button-back-arrow-box):not(.duel-toggle-button) {
 }
 
 ::-webkit-scrollbar {
-	display: none;
+	width: 0.8rem;
+}
+
+::-webkit-scrollbar-thumb {
+	background-color: #ffffff;
+	border-radius: 0.4rem;
+}
+
+::-webkit-scrollbar-track {
+	/* 투명도 50% */
+	background-color: rgba(255, 255, 255, 0.3);
+	border-radius: 0.4rem;
 }
 
 .loading-container {
@@ -994,6 +1006,7 @@ td {
 	width: 78rem;
 	height: 56rem;
 	overflow: scroll;
+	overflow-x: hidden;
 }
 
 .duel-report-wrapper {

--- a/FE/src/index.js
+++ b/FE/src/index.js
@@ -68,8 +68,18 @@ export const changeUrlData = (url, data) => {
 // When the user presses the back or forward button, the page is changed
 window.onpopstate = () => {
 	const url = window.location.href.split('/').pop();
-	root.innerHTML = routes[url].template();
-	routes[url].addEventListeners();
+	if (
+		url === 'game' ||
+		url === 'duelstats' ||
+		url === 'tournament' ||
+		url === 'tournamentResult'
+	) {
+		alert('유효하지 않은 요청입니다.');
+		history.go(1);
+	} else {
+		root.innerHTML = routes[url].template();
+		routes[url].addEventListeners();
+	}
 };
 
 // 새로 고침 시 홈페이지로 주소 변경

--- a/FE/src/index.js
+++ b/FE/src/index.js
@@ -67,6 +67,7 @@ export const changeUrlData = (url, data) => {
 
 // When the user presses the back or forward button, the page is changed
 window.onpopstate = () => {
+	// 링크가 변경되기 전에 유효하지 않은 요청인지 확인
 	const url = window.location.href.split('/').pop();
 	if (
 		url === 'game' ||
@@ -75,7 +76,7 @@ window.onpopstate = () => {
 		url === 'tournamentResult'
 	) {
 		alert('유효하지 않은 요청입니다.');
-		history.go(1);
+		changeUrl('');
 	} else {
 		root.innerHTML = routes[url].template();
 		routes[url].addEventListeners();

--- a/FE/src/index.js
+++ b/FE/src/index.js
@@ -71,3 +71,8 @@ window.onpopstate = () => {
 	root.innerHTML = routes[url].template();
 	routes[url].addEventListeners();
 };
+
+// 새로 고침 시 홈페이지로 주소 변경
+window.onload = () => {
+	history.pushState(null, null, homeLink);
+};

--- a/FE/src/pages/MatchModePage.js
+++ b/FE/src/pages/MatchModePage.js
@@ -18,7 +18,9 @@ class MatchModePage {
 				<div class="select-wrapper button-click-tournament">
 					${tournamentButton.template()}
 				</div>
-				<div class="back-arrow-container">${backButton.template()}</div>
+				<div class="back-arrow-container">
+					<div class="back-arrow">${backButton.template()}</div>
+				</div>
 			</div>
 		`;
 	}
@@ -32,7 +34,7 @@ class MatchModePage {
 		tournament.addEventListener('click', () => {
 			changeUrlData('gameSettingTournament', null);
 		});
-		const back = document.querySelector('.back-arrow-container');
+		const back = document.querySelector('.back-arrow');
 		back.addEventListener('click', () => {
 			changeUrl('play');
 		});

--- a/FE/src/pages/PlayModePage.js
+++ b/FE/src/pages/PlayModePage.js
@@ -18,7 +18,10 @@ class PlayModePage {
 				<div class="select-wrapper button-click-online">
 					${onlineButton.template()}
 				</div>
-				<div class="back-arrow-container">${backButton.template()}</div>
+
+				<div class="back-arrow-container">
+					<div class="back-arrow">${backButton.template()}</div>
+				</div>
 			</div>
 		`;
 	}
@@ -32,7 +35,7 @@ class PlayModePage {
 		online.addEventListener('click', () => {
 			console.log('online button click!');
 		});
-		const back = document.querySelector('.back-arrow-container');
+		const back = document.querySelector('.back-arrow');
 		back.addEventListener('click', () => {
 			changeUrl('');
 		});

--- a/FE/src/pages/RegisterNicknamePage.js
+++ b/FE/src/pages/RegisterNicknamePage.js
@@ -22,7 +22,10 @@ class RegisterNicknamePage {
 				<div class="register-next" style="margin-top: 35rem">
 					${nextButton.template()}
 				</div>
-				<div class="back-arrow-container">${backButton.template()}</div>
+
+				<div class="back-arrow-container">
+					<div class="back-arrow">${backButton.template()}</div>
+				</div>
 			</div>
 		`;
 	}
@@ -32,7 +35,7 @@ class RegisterNicknamePage {
 		next.addEventListener('click', () => {
 			changeUrl('');
 		});
-		const back = document.querySelector('.back-arrow-container');
+		const back = document.querySelector('.back-arrow');
 		back.addEventListener('click', () => {
 			changeUrl('register');
 		});

--- a/FE/src/pages/RegisterPage.js
+++ b/FE/src/pages/RegisterPage.js
@@ -30,7 +30,9 @@ class RegisterPage {
 					${nextButton.template()}
 				</div>
 
-				<div class="back-arrow-container">${backButton.template()}</div>
+				<div class="back-arrow-container">
+					<div class="back-arrow">${backButton.template()}</div>
+				</div>
 			</div>
 		`;
 	}
@@ -40,7 +42,7 @@ class RegisterPage {
 		next.addEventListener('click', () => {
 			changeUrl('registerNickname');
 		});
-		const back = document.querySelector('.back-arrow-container');
+		const back = document.querySelector('.back-arrow');
 		back.addEventListener('click', () => {
 			changeUrl('');
 		});

--- a/FE/src/pages/TournamentPage.js
+++ b/FE/src/pages/TournamentPage.js
@@ -21,7 +21,10 @@ class TournamentPage {
 		return html`
 			<div class="medium-window head_white_neon_15">
 				${titlComponent.template()}
-				<div class="medium-window-container display-light18">
+				<div
+					class="medium-window-container display-light18"
+					style="overflow: hidden;"
+				>
 					${openBracket}
 				</div>
 				<div class="event-click-match" style="margin-top: 4rem">


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

스크롤바 추가, 새로 고침 시 홈페이지로 링크 변경, history 로직 약간 수정 등

## 🧑‍💻 PR 세부 내용

- 스크롤바 추가
- 새로 고침 시 홈페이지로 링크 변경
  - 링크도 변경되고 화면도 변경됨
  - 기존 페이지의 히스토리는 다 삭제됨
- history 로직 약간 수정
  - game, duelstats, tournament, tournamentResult으로 history 변경하려고 할 경우
  - 유효하지 않으므로 alert 띄우고 변경하지 않음.
  - 링크도 변경하지 않음. (대신 alert이 떠있는 상태에서 다시 뒤로가기 하면 변경됨.)

## 📸 스크린샷

<img width="1680" alt="스크린샷 2024-03-28 오후 9 29 11" src="https://github.com/authenticity-house/ft_transcendence/assets/49023654/cfc1dff3-df42-4b9a-95df-e78833b1c2e4">

<img width="1680" alt="스크린샷 2024-03-28 오후 9 29 24" src="https://github.com/authenticity-house/ft_transcendence/assets/49023654/ee0f15c3-0eab-4aec-b925-827306fcc61c">

<img width="1680" alt="스크린샷 2024-03-28 오후 9 29 32" src="https://github.com/authenticity-house/ft_transcendence/assets/49023654/537e1d23-83c8-4b37-9581-f2c4199c64bc">

<img width="1680" alt="스크린샷 2024-03-28 오후 9 30 07" src="https://github.com/authenticity-house/ft_transcendence/assets/49023654/8d102348-6a8a-4b2c-ad00-f36082574291">
-> 게임 화면으로 history 이동하려고 할 경우 

<img width="1680" alt="스크린샷 2024-03-28 오후 9 29 46" src="https://github.com/authenticity-house/ft_transcendence/assets/49023654/8580ff07-a2f6-4506-9760-9005891e2a9b">
-> duelstats로 history 이동하려고 할 경우


## 📚 관련 이슈

#103 
