### PR TITLE
[Refactor] 프론트 websocket 관련 부분 리팩토링

### DIFF
--- a/FE/src/Gamewebsocket.js
+++ b/FE/src/Gamewebsocket.js
@@ -1,12 +1,18 @@
 /* eslint-disable no-void */
 import { changeUrlData } from './index.js';
 import { removeModalBackdrop } from './components/modal/modalUtiils.js';
+import { gameSessionInfoMsg } from './websocket/websocketUtils.js';
+
+// const { port } = location;
 
 export class Gamewebsocket {
 	constructor(initial) {
 		this.initial = initial;
 
-		const ws = new WebSocket('ws://localhost:8080/ws/game-server/');
+		// const ws = new WebSocket(`ws://localhost:${port}/ws/game-server/`);
+
+		const ws = new WebSocket(`ws://localhost:8080/ws/game-server/`);
+		this.ws = ws;
 		this.ws = ws;
 
 		this.gamesetting = {};
@@ -87,7 +93,8 @@ export class Gamewebsocket {
 
 	// --------------------- utils ---------------------
 	send(data) {
-		this.ws.send(data);
+		console.log(data);
+		this.ws.send(JSON.stringify(data));
 	}
 
 	close() {
@@ -101,64 +108,13 @@ export class Gamewebsocket {
 	setGameSetting(data) {
 		this.gamesetting = data;
 	}
-	// -------------------------- send message --------------------------------
-
-	sendGameSessionInfo() {
-		const message = {
-			type: 'game',
-			subtype: 'session_info',
-			message: '',
-			data: this.initial
-		};
-		// 임시로 1로 설정
-		// message.data.total_score = 1;
-		this.ws.send(JSON.stringify(message));
-	}
-
-	sendGameMatchInitSetting() {
-		const message = {
-			type: 'game',
-			subtype: 'match_init_setting',
-			message: 'go!',
-			data: {}
-		};
-		this.ws.send(JSON.stringify(message));
-	}
-
-	sendGameStartRequest() {
-		const message = {
-			type: 'game',
-			subtype: 'match_start',
-			message: 'go!',
-			data: '',
-			match_id: 123
-		};
-		this.ws.send(JSON.stringify(message));
-	}
-
-	sendGameNextMatch() {
-		const message = {
-			type: 'game',
-			subtype: 'next_match',
-			message: 'go!'
-		};
-		this.ws.send(JSON.stringify(message));
-	}
-
-	sendGameOver() {
-		const message = {
-			type: 'game_over',
-			subtype: 'summary',
-			message: 'go!'
-		};
-		this.ws.send(JSON.stringify(message));
-	}
 
 	sendGameDisconnect() {
 		const message = {
 			type: 'disconnect',
 			message: "I'm leaving!"
 		};
+
 		this.ws.send(JSON.stringify(message));
 		this.ws.close();
 		console.log('disconnected');
@@ -257,13 +213,12 @@ export class Gamewebsocket {
 			switch (message.type) {
 				case 'game':
 					if (message.subtype === 'connection_established') {
-						this.sendGameSessionInfo();
+						this.send(gameSessionInfoMsg(this.initial));
 					} else if (message.subtype === 'tournament_tree') {
 						message.data.Gamewebsocket = this;
 						changeUrlData('tournament', message.data);
 					} else if (message.subtype === 'match_init_setting') {
 						this.gamesetting = message.data;
-						// this.sendGameStartRequest();
 						message.data.Gamewebsocket = this;
 						changeUrlData('game', message.data);
 					} else if (message.subtype === 'match_run') {

--- a/FE/src/index.js
+++ b/FE/src/index.js
@@ -46,6 +46,12 @@ const routes = {
 root.innerHTML = routes[''].template();
 routes[''].addEventListeners();
 
+export const changeUrlInstance = (url, instance) => {
+	// history.pushState(null, null, `${homeLink}${url}`);
+	root.innerHTML = instance.template();
+	instance.addEventListeners();
+};
+
 // When the user presses the back or forward button, the page is changed
 export const changeUrl = (url) => {
 	history.pushState(null, null, `${homeLink}${url}`);

--- a/FE/src/pages/DuelStatsPage.js
+++ b/FE/src/pages/DuelStatsPage.js
@@ -5,7 +5,6 @@ import DuelStatsData from '../components/DuelStatsData.js';
 import DuelBasicStats from '../components/DuelBasicStats.js';
 import DuelSpecialStats from '../components/DuelSpecialStats.js';
 import DuelGraphStats from '../components/DuelGraphStats.js';
-import { gameNextMatchMsg } from '../websocket/websocketUtils.js';
 
 const html = String.raw;
 
@@ -48,15 +47,6 @@ class DuelStatsPage {
 		`;
 	}
 
-	addEventListeners() {
-		const back = document.querySelector('.event-click-match');
-		back.addEventListener('click', () => {
-			if (this.data.Gamewebsocket) {
-				this.data.Gamewebsocket.send(gameNextMatchMsg());
-			} else changeUrl('match');
-		});
-	}
-
 	mount(data) {
 		const matchData = DuelStatsData.getMountDuelStatsData(data);
 		// score-trend
@@ -70,6 +60,15 @@ class DuelStatsPage {
 			matchData.leftPosition,
 			matchData.rightPosition
 		);
+	}
+
+	addEventListeners() {
+		const back = document.querySelector('.event-click-match');
+		back.addEventListener('click', () => {
+			if (this.data.sendMsg) {
+				this.data.sendMsg();
+			} else changeUrl('match');
+		});
 	}
 }
 

--- a/FE/src/pages/DuelStatsPage.js
+++ b/FE/src/pages/DuelStatsPage.js
@@ -5,6 +5,7 @@ import DuelStatsData from '../components/DuelStatsData.js';
 import DuelBasicStats from '../components/DuelBasicStats.js';
 import DuelSpecialStats from '../components/DuelSpecialStats.js';
 import DuelGraphStats from '../components/DuelGraphStats.js';
+import { gameNextMatchMsg } from '../websocket/websocketUtils.js';
 
 const html = String.raw;
 
@@ -51,7 +52,7 @@ class DuelStatsPage {
 		const back = document.querySelector('.event-click-match');
 		back.addEventListener('click', () => {
 			if (this.data.Gamewebsocket) {
-				this.data.Gamewebsocket.sendGameNextMatch();
+				this.data.Gamewebsocket.send(gameNextMatchMsg());
 			} else changeUrl('match');
 		});
 	}

--- a/FE/src/pages/DuelStatsPage.js
+++ b/FE/src/pages/DuelStatsPage.js
@@ -65,9 +65,9 @@ class DuelStatsPage {
 	addEventListeners() {
 		const back = document.querySelector('.event-click-match');
 		back.addEventListener('click', () => {
-			if (this.data.sendMsg) {
-				this.data.sendMsg();
-			} else changeUrl('match');
+			this.data.sendMsg();
+			if (this.data.sendMsg.name === 'bound sendGameDisconnect')
+				changeUrl('match');
 		});
 	}
 }

--- a/FE/src/pages/GamePage.js
+++ b/FE/src/pages/GamePage.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-void */
-
 import * as THREE from 'three';
 import { FontLoader } from '../../node_modules/three/examples/jsm/loaders/FontLoader.js';
 import { TextGeometry } from '../../node_modules/three/examples/jsm/geometries/TextGeometry.js';
@@ -270,15 +268,11 @@ class GamePage {
 			renderer.setSize(window.innerWidth / 1.8, window.innerHeight / 1.8);
 		});
 
-		// this.initial.Gamewebsocket.addListeners();
-		// this.initial.Gamewebsocket.send(gameStartRequestMsg());
-
 		// -------------------------------------------------------------------------------------------------------------------------
 		// Return to the main page
 
 		const returnButton = document.querySelector('.return-button');
 		returnButton.addEventListener('click', () => {
-			// this.initial.Gamewebsocket.sendGameDisconnect();
 			this.initial.sendMsg();
 
 			console.log('match_end');

--- a/FE/src/pages/GamePage.js
+++ b/FE/src/pages/GamePage.js
@@ -11,14 +11,11 @@ import { gameStartRequestMsg } from '../websocket/websocketUtils.js';
 const html = String.raw;
 
 class GamePage {
-	constructor() {
-		this.initial = {};
+	constructor(initial) {
+		this.initial = initial;
 	}
 
-	template(initial) {
-		this.initial = initial;
-		console.log(initial);
-
+	template() {
 		return html`
 			<div class="game-page-container">
 				<div class="game-page-container">
@@ -274,10 +271,7 @@ class GamePage {
 			renderer.setSize(window.innerWidth / 1.8, window.innerHeight / 1.8);
 		});
 
-		this.initial.Gamewebsocket.gamepage = this;
-
 		this.initial.Gamewebsocket.addListeners();
-
 		this.initial.Gamewebsocket.send(gameStartRequestMsg());
 
 		// -------------------------------------------------------------------------------------------------------------------------
@@ -292,4 +286,6 @@ class GamePage {
 	}
 }
 
-export default new GamePage();
+export default GamePage;
+
+// export default new GamePage();

--- a/FE/src/pages/GamePage.js
+++ b/FE/src/pages/GamePage.js
@@ -106,6 +106,7 @@ class GamePage {
 		);
 		lineDashed.computeLineDistances();
 		scene.add(lineDashed);
+
 		// ---------------------------------------------------------------
 		// ----------------------------- ball ----------------------------
 		// Create a ball
@@ -128,7 +129,7 @@ class GamePage {
 		ballLight.position.set(0, 0, 0);
 		scene.add(ballLight);
 
-		// --------------------- paddle -------------------------
+		// -------------------------- paddle -----------------------------
 		// Create a paddle
 		const paddle = new THREE.BoxGeometry(
 			this.initial.paddle1.width,
@@ -247,7 +248,9 @@ class GamePage {
 			textMesh.position.z = 0.5;
 			scene.add(textMesh);
 		});
+
 		// ---------------------------------------------------------------
+
 		renderer.render(scene, camera);
 
 		this.camera = camera;
@@ -260,6 +263,7 @@ class GamePage {
 		this.ballMesh = ballMesh;
 		this.ballLight = ballLight;
 
+		// ---------------------------------------------------------------
 		// Resize the window
 		window.addEventListener('resize', () => {
 			camera.aspect = window.innerWidth / window.innerHeight;
@@ -268,7 +272,7 @@ class GamePage {
 			renderer.setSize(window.innerWidth / 1.8, window.innerHeight / 1.8);
 		});
 
-		// -------------------------------------------------------------------------------------------------------------------------
+		// ---------------------------------------------------------------
 		// Return to the main page
 
 		const returnButton = document.querySelector('.return-button');

--- a/FE/src/pages/GamePage.js
+++ b/FE/src/pages/GamePage.js
@@ -6,7 +6,6 @@ import { TextGeometry } from '../../node_modules/three/examples/jsm/geometries/T
 
 import { changeUrl } from '../index.js';
 import { exitModal } from '../components/modal/exitModal.js';
-import { gameStartRequestMsg } from '../websocket/websocketUtils.js';
 
 const html = String.raw;
 
@@ -271,15 +270,17 @@ class GamePage {
 			renderer.setSize(window.innerWidth / 1.8, window.innerHeight / 1.8);
 		});
 
-		this.initial.Gamewebsocket.addListeners();
-		this.initial.Gamewebsocket.send(gameStartRequestMsg());
+		// this.initial.Gamewebsocket.addListeners();
+		// this.initial.Gamewebsocket.send(gameStartRequestMsg());
 
 		// -------------------------------------------------------------------------------------------------------------------------
 		// Return to the main page
 
 		const returnButton = document.querySelector('.return-button');
 		returnButton.addEventListener('click', () => {
-			this.initial.Gamewebsocket.sendGameDisconnect();
+			// this.initial.Gamewebsocket.sendGameDisconnect();
+			this.initial.sendMsg();
+
 			console.log('match_end');
 			changeUrl('match');
 		});
@@ -287,5 +288,3 @@ class GamePage {
 }
 
 export default GamePage;
-
-// export default new GamePage();

--- a/FE/src/pages/GamePage.js
+++ b/FE/src/pages/GamePage.js
@@ -6,6 +6,7 @@ import { TextGeometry } from '../../node_modules/three/examples/jsm/geometries/T
 
 import { changeUrl } from '../index.js';
 import { exitModal } from '../components/modal/exitModal.js';
+import { gameStartRequestMsg } from '../websocket/websocketUtils.js';
 
 const html = String.raw;
 
@@ -277,7 +278,7 @@ class GamePage {
 
 		this.initial.Gamewebsocket.addListeners();
 
-		this.initial.Gamewebsocket.sendGameStartRequest();
+		this.initial.Gamewebsocket.send(gameStartRequestMsg());
 
 		// -------------------------------------------------------------------------------------------------------------------------
 		// Return to the main page

--- a/FE/src/pages/GameSettingPage.js
+++ b/FE/src/pages/GameSettingPage.js
@@ -1,7 +1,7 @@
 import { changeUrlData } from '../index.js';
 import HorizontalButton from '../components/HorizontalButton.js';
 import VerticalButton from '../components/VerticalButton.js';
-import { Gamewebsocket } from '../Gamewebsocket.js';
+import { Gamewebsocket } from '../websocket/Gamewebsocket.js';
 
 const html = String.raw;
 

--- a/FE/src/pages/GameSettingTournament.js
+++ b/FE/src/pages/GameSettingTournament.js
@@ -2,7 +2,7 @@ import { changeUrlData } from '../index.js';
 import HorizontalButton from '../components/HorizontalButton.js';
 import VerticalButton from '../components/VerticalButton.js';
 import InputNickname from '../components/InputNickname.js';
-import { Gamewebsocket } from '../Gamewebsocket.js';
+import Gamewebsocket from '../websocket/Gamewebsocket.js';
 
 const html = String.raw;
 

--- a/FE/src/pages/GameSettingTournament.js
+++ b/FE/src/pages/GameSettingTournament.js
@@ -192,11 +192,12 @@ class GameSettingTournament {
 		startButton.addEventListener('click', () => {
 			const newData = this.data;
 			this.resetData();
+
 			updateNicknamesData(newData);
 			newData.total_score *= 5;
+
 			const gamewebsocket = new Gamewebsocket(newData);
 			console.log(gamewebsocket);
-			// changeUrlData('game', newData);
 		});
 	}
 }

--- a/FE/src/pages/GameSettingTournament.js
+++ b/FE/src/pages/GameSettingTournament.js
@@ -2,7 +2,7 @@ import { changeUrlData } from '../index.js';
 import HorizontalButton from '../components/HorizontalButton.js';
 import VerticalButton from '../components/VerticalButton.js';
 import InputNickname from '../components/InputNickname.js';
-import Gamewebsocket from '../websocket/Gamewebsocket.js';
+import { Gamewebsocket } from '../websocket/Gamewebsocket.js';
 
 const html = String.raw;
 

--- a/FE/src/pages/TournamentPage.js
+++ b/FE/src/pages/TournamentPage.js
@@ -7,11 +7,6 @@ import {
 	getUserPosition
 } from '../components/TournamentBracket.js';
 
-import {
-	gameMatchInitSettingMsg,
-	gameOverMsg
-} from '../websocket/websocketUtils.js';
-
 const html = String.raw;
 
 class TournamentPage {
@@ -66,11 +61,7 @@ class TournamentPage {
 	addEventListeners() {
 		const next = document.querySelector('.event-click-match');
 		next.addEventListener('click', () => {
-			if (this.data.gameOver === true) {
-				this.data.Gamewebsocket.send(gameOverMsg());
-			} else {
-				this.data.Gamewebsocket.send(gameMatchInitSettingMsg());
-			}
+			this.data.sendMsg();
 		});
 	}
 }

--- a/FE/src/pages/TournamentPage.js
+++ b/FE/src/pages/TournamentPage.js
@@ -61,6 +61,7 @@ class TournamentPage {
 	addEventListeners() {
 		const next = document.querySelector('.event-click-match');
 		next.addEventListener('click', () => {
+			// 게임 매치 초기화 요청, MatchInitSettingMsg 전송
 			this.data.sendMsg();
 		});
 	}

--- a/FE/src/pages/TournamentPage.js
+++ b/FE/src/pages/TournamentPage.js
@@ -7,6 +7,11 @@ import {
 	getUserPosition
 } from '../components/TournamentBracket.js';
 
+import {
+	gameMatchInitSettingMsg,
+	gameOverMsg
+} from '../websocket/websocketUtils.js';
+
 const html = String.raw;
 
 class TournamentPage {
@@ -62,9 +67,9 @@ class TournamentPage {
 		const next = document.querySelector('.event-click-match');
 		next.addEventListener('click', () => {
 			if (this.data.gameOver === true) {
-				this.data.Gamewebsocket.sendGameOver();
+				this.data.Gamewebsocket.send(gameOverMsg());
 			} else {
-				this.data.Gamewebsocket.sendGameMatchInitSetting();
+				this.data.Gamewebsocket.send(gameMatchInitSettingMsg());
 			}
 		});
 	}

--- a/FE/src/pages/TournamentResultPage.js
+++ b/FE/src/pages/TournamentResultPage.js
@@ -17,7 +17,7 @@ class TournamentResultPage {
 		const titlComponent = new BoldTitle('게임 결과', 'yellow');
 		const exitButton = new ButtonSmall('나가기');
 		let duelReports = '';
-		// console.log('한 묶음 데이터!');
+
 		for (let i = 0; i < content.length; i += 1) {
 			const resultData = DuelStatsData.getDuelStatsData(content[i]);
 			const matchRallyHtml = DuelBasicStats.getMatchRallyHTML(resultData);
@@ -46,10 +46,13 @@ class TournamentResultPage {
 	}
 
 	mount(data) {
+		this.data = data;
+		const { content } = this.data;
 		let i = 0;
+
 		const graphContainers = document.querySelectorAll('.graph-container');
 		graphContainers.forEach((graphContainer) => {
-			const matchData = DuelStatsData.getMountDuelStatsData(data[i]);
+			const matchData = DuelStatsData.getMountDuelStatsData(content[i]);
 			// score-trend
 			DuelGraphStats.appendScoresToYAxis(matchData.maxScore, graphContainer);
 			DuelGraphStats.appendScoreTrendGraph(

--- a/FE/src/pages/TournamentResultPage.js
+++ b/FE/src/pages/TournamentResultPage.js
@@ -12,13 +12,14 @@ const html = String.raw;
 class TournamentResultPage {
 	template(data) {
 		this.data = data;
+		const { content } = this.data;
 
 		const titlComponent = new BoldTitle('게임 결과', 'yellow');
 		const exitButton = new ButtonSmall('나가기');
 		let duelReports = '';
 		// console.log('한 묶음 데이터!');
-		for (let i = 0; i < data.length; i += 1) {
-			const resultData = DuelStatsData.getDuelStatsData(data[i]);
+		for (let i = 0; i < content.length; i += 1) {
+			const resultData = DuelStatsData.getDuelStatsData(content[i]);
 			const matchRallyHtml = DuelBasicStats.getMatchRallyHTML(resultData);
 			const specialStatsHtml = DuelSpecialStats.getSpecialStatsHTML(resultData);
 			const scoreTrendHtml = DuelGraphStats.getScoreTrendHTML(resultData);
@@ -89,7 +90,7 @@ class TournamentResultPage {
 
 		const exit = document.querySelector('.exit-button');
 		exit.addEventListener('click', () => {
-			this.data.Gamewebsocket.sendGameDisconnect();
+			this.data.sendMsg();
 			changeUrl('match');
 		});
 	}

--- a/FE/src/websocket/Gamewebsocket.js
+++ b/FE/src/websocket/Gamewebsocket.js
@@ -1,12 +1,19 @@
 import { MessageManager } from './MessageManager.js';
 
-const { port } = location;
-
 export class Gamewebsocket {
 	constructor(initial) {
 		this.initial = initial;
 
-		this.ws = new WebSocket(`ws://localhost:${port}/ws/game-server/`);
+		const { protocol, hostname, port } = location;
+
+		// 보안 연결(HTTPS)인 경우 wss를, 아니면 ws를 사용
+		const wsProtocol = protocol === 'https:' ? 'wss' : 'ws';
+		// 포트 번호가 있으면 URL에 포함시키고, 없으면 포트 번호 없이 도메인만 사용
+		const wsPort = port ? `:${port}` : '';
+		const wsUrl = `${wsProtocol}://${hostname}${wsPort}/ws/game-server/`;
+
+		this.ws = new WebSocket(wsUrl);
+
 		this.messageManager = new MessageManager(this);
 
 		this.gamesetting = {};

--- a/FE/src/websocket/Gamewebsocket.js
+++ b/FE/src/websocket/Gamewebsocket.js
@@ -35,16 +35,11 @@ export class Gamewebsocket {
 	}
 
 	close() {
-		console.log('close');
 		this.ws.close();
 	}
 
 	isOpen() {
 		return this.ws.readyState === this.ws.OPEN;
-	}
-
-	setGameSetting(data) {
-		this.gamesetting = data;
 	}
 
 	// -------------------------------------------------

--- a/FE/src/websocket/Gamewebsocket.js
+++ b/FE/src/websocket/Gamewebsocket.js
@@ -1,8 +1,3 @@
-/* eslint-disable no-void */
-// import { changeUrlInstance, changeUrlData } from '../index.js';
-// import { removeModalBackdrop } from '../components/modal/modalUtiils.js';
-// import { gameSessionInfoMsg } from './messages.js';
-// import GamePage from '../pages/GamePage.js';
 import { MessageManager } from './MessageManager.js';
 
 const { port } = location;
@@ -28,7 +23,7 @@ export class Gamewebsocket {
 		this.initializeEventListeners();
 	}
 
-	// ---------------------------------------------
+	// -----------------------------------------------------------------------------
 
 	send(message) {
 		this.ws.send(JSON.stringify(message));
@@ -42,7 +37,7 @@ export class Gamewebsocket {
 		return this.ws.readyState === this.ws.OPEN;
 	}
 
-	// -------------------------------------------------
+	// -----------------------------------------------------------------------------
 
 	initializeEventListeners() {
 		document.addEventListener('keydown', (event) => this.handleKeyDown(event));
@@ -90,12 +85,5 @@ export class Gamewebsocket {
 			const message = JSON.parse(e.data);
 			this.messageManager.handleMessage(message);
 		};
-	}
-
-	addListeners() {
-		this.player1Score = document.querySelector('.player1');
-		this.player2Score = document.querySelector('.player2');
-		this.gameResult = document.querySelector('.game-result');
-		this.winner = 0;
 	}
 }

--- a/FE/src/websocket/Gamewebsocket.js
+++ b/FE/src/websocket/Gamewebsocket.js
@@ -19,6 +19,7 @@ export class Gamewebsocket {
 		this.gameResult = null;
 		this.frame = 0;
 		this.winner = 0;
+		this.keyDownList = new Set();
 		ws.onopen = () => {
 			console.log('connected');
 			this.receiveMessages();
@@ -27,6 +28,25 @@ export class Gamewebsocket {
 	}
 
 	// ---------------------------------------------
+
+	send(message) {
+		this.ws.send(JSON.stringify(message));
+	}
+
+	close() {
+		this.ws.close();
+	}
+
+	isOpen() {
+		return this.ws.readyState === this.ws.OPEN;
+	}
+
+	setGameSetting(data) {
+		this.gamesetting = data;
+	}
+
+	// -------------------------------------------------
+
 	initializeEventListeners() {
 		document.addEventListener('keydown', (event) => this.handleKeyDown(event));
 		document.addEventListener('keyup', (event) => this.handleKeyUp(event));
@@ -55,7 +75,7 @@ export class Gamewebsocket {
 	}
 
 	sendKeySet() {
-		const message = JSON.stringify({
+		const message = {
 			type: 'game',
 			subtype: 'key_down',
 			message: 'key!',
@@ -63,28 +83,11 @@ export class Gamewebsocket {
 			data: {
 				key_set: Array.from(this.keyDownList)
 			}
-		});
-		this.ws.send(message);
+		};
+		this.send(message);
 	}
 
-	// --------------------- utils ---------------------
-	send(data) {
-		console.log(data);
-		this.ws.send(JSON.stringify(data));
-	}
-
-	close() {
-		this.ws.close();
-	}
-
-	isOpen() {
-		return this.ws.readyState === this.ws.OPEN;
-	}
-
-	setGameSetting(data) {
-		this.gamesetting = data;
-	}
-
+	// --------------------------------------------
 	sendGameDisconnect() {
 		const message = {
 			type: 'disconnect',

--- a/FE/src/websocket/Gamewebsocket.js
+++ b/FE/src/websocket/Gamewebsocket.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-void */
-import { changeUrlData } from './index.js';
-import { removeModalBackdrop } from './components/modal/modalUtiils.js';
-import { gameSessionInfoMsg } from './websocket/websocketUtils.js';
+import { changeUrlData } from '../index.js';
+import { removeModalBackdrop } from '../components/modal/modalUtiils.js';
+import { gameSessionInfoMsg } from './websocketUtils.js';
 
 // const { port } = location;
 

--- a/FE/src/websocket/Gamewebsocket.js
+++ b/FE/src/websocket/Gamewebsocket.js
@@ -3,15 +3,13 @@ import { changeUrlData } from '../index.js';
 import { removeModalBackdrop } from '../components/modal/modalUtiils.js';
 import { gameSessionInfoMsg } from './websocketUtils.js';
 
-// const { port } = location;
+const { port } = location;
 
 export class Gamewebsocket {
 	constructor(initial) {
 		this.initial = initial;
 
-		// const ws = new WebSocket(`ws://localhost:${port}/ws/game-server/`);
-
-		const ws = new WebSocket(`ws://localhost:8080/ws/game-server/`);
+		const ws = new WebSocket(`ws://localhost:${port}/ws/game-server/`);
 		this.ws = ws;
 		this.ws = ws;
 

--- a/FE/src/websocket/Gamewebsocket.js
+++ b/FE/src/websocket/Gamewebsocket.js
@@ -46,7 +46,7 @@ export class Gamewebsocket {
 		// 포트 번호가 있으면 URL에 포함시키고, 없으면 포트 번호 없이 도메인만 사용
 		const wsPort = port ? `:${port}` : '';
 		const wsUrl = `${wsProtocol}://${hostname}${wsPort}/ws/game-server/`;
-		console.log(wsUrl);
+
 		return wsUrl;
 	}
 

--- a/FE/src/websocket/Gamewebsocket.js
+++ b/FE/src/websocket/Gamewebsocket.js
@@ -4,15 +4,7 @@ export class Gamewebsocket {
 	constructor(initial) {
 		this.initial = initial;
 
-		const { protocol, hostname, port } = location;
-
-		// 보안 연결(HTTPS)인 경우 wss를, 아니면 ws를 사용
-		const wsProtocol = protocol === 'https:' ? 'wss' : 'ws';
-		// 포트 번호가 있으면 URL에 포함시키고, 없으면 포트 번호 없이 도메인만 사용
-		const wsPort = port ? `:${port}` : '';
-		const wsUrl = `${wsProtocol}://${hostname}${wsPort}/ws/game-server/`;
-
-		this.ws = new WebSocket(wsUrl);
+		this.ws = new WebSocket(this.getUrl());
 
 		this.messageManager = new MessageManager(this);
 
@@ -45,6 +37,18 @@ export class Gamewebsocket {
 	}
 
 	// -----------------------------------------------------------------------------
+
+	getUrl() {
+		const { protocol, hostname, port } = location;
+
+		// HTTPS인 경우 wss, 아니면 ws
+		const wsProtocol = protocol === 'https:' ? 'wss' : 'ws';
+		// 포트 번호가 있으면 URL에 포함시키고, 없으면 포트 번호 없이 도메인만 사용
+		const wsPort = port ? `:${port}` : '';
+		const wsUrl = `${wsProtocol}://${hostname}${wsPort}/ws/game-server/`;
+		console.log(wsUrl);
+		return wsUrl;
+	}
 
 	initializeEventListeners() {
 		document.addEventListener('keydown', (event) => this.handleKeyDown(event));

--- a/FE/src/websocket/Gamewebsocket.js
+++ b/FE/src/websocket/Gamewebsocket.js
@@ -1,8 +1,9 @@
 /* eslint-disable no-void */
-import { changeUrlInstance, changeUrlData } from '../index.js';
-import { removeModalBackdrop } from '../components/modal/modalUtiils.js';
-import { gameSessionInfoMsg } from './websocketUtils.js';
-import GamePage from '../pages/GamePage.js';
+// import { changeUrlInstance, changeUrlData } from '../index.js';
+// import { removeModalBackdrop } from '../components/modal/modalUtiils.js';
+// import { gameSessionInfoMsg } from './messages.js';
+// import GamePage from '../pages/GamePage.js';
+import { MessageManager } from './MessageManager.js';
 
 const { port } = location;
 
@@ -10,17 +11,17 @@ export class Gamewebsocket {
 	constructor(initial) {
 		this.initial = initial;
 
-		const ws = new WebSocket(`ws://localhost:${port}/ws/game-server/`);
-		this.ws = ws;
+		this.ws = new WebSocket(`ws://localhost:${port}/ws/game-server/`);
+		this.messageManager = new MessageManager(this);
+
 		this.gamesetting = {};
-		this.gamepage = null;
 		this.player1Score = null;
 		this.player2Score = null;
 		this.gameResult = null;
-		this.frame = 0;
 		this.winner = 0;
 		this.keyDownList = new Set();
-		ws.onopen = () => {
+
+		this.ws.onopen = () => {
 			console.log('connected');
 			this.receiveMessages();
 		};
@@ -34,6 +35,7 @@ export class Gamewebsocket {
 	}
 
 	close() {
+		console.log('close');
 		this.ws.close();
 	}
 
@@ -87,168 +89,12 @@ export class Gamewebsocket {
 		this.send(message);
 	}
 
-	// --------------------------------------------
-	sendGameDisconnect() {
-		const message = {
-			type: 'disconnect',
-			message: "I'm leaving!"
-		};
-		this.send(message);
-		this.ws.close();
-		console.log('disconnected');
-	}
-
-	// ----------------------------------------------------------
-	// --------------------- game ---------------------
-	renderThreeJs(data) {
-		this.frame += 1;
-		if (Number(this.player1Score.textContent) === this.initial.total_score) {
-			this.winner = 1;
-		}
-		if (Number(this.player2Score.textContent) === this.initial.total_score) {
-			this.winner = 2;
-		}
-
-		if (this.frame < 100) {
-			this.gamepage.camera.position.x = -4;
-			this.gamepage.camera.position.y = -1 + (this.frame / 100) * 2;
-			this.gamepage.camera.lookAt(this.gamepage.paddleMesh1.position);
-		}
-		if (this.frame >= 100 && this.frame < 200) {
-			this.gamepage.camera.position.x = 4;
-			this.gamepage.camera.position.y = 1 - ((this.frame - 100) / 100) * 2;
-			this.gamepage.camera.lookAt(this.gamepage.paddleMesh2.position);
-		}
-		if (this.frame >= 200 && this.frame <= 300) {
-			this.gamepage.camera.position.x = 0;
-			this.gamepage.camera.position.y = 0;
-			this.gamepage.camera.position.z =
-				3.5 +
-				Math.sin((3 / 2) * Math.PI + ((this.frame - 200) / 100) * Math.PI) *
-					(1 / 2);
-			this.gamepage.camera.lookAt(0, 0, 0);
-			if (this.frame === 200) {
-				this.gamepage.scene.children[
-					this.gamepage.scene.children.length - 1
-				].visible = true;
-			}
-			if (this.frame >= 275 && this.frame < 300 && this.frame % 4 === 0) {
-				this.gamepage.scene.children[
-					this.gamepage.scene.children.length - 1
-				].visible =
-					!this.gamepage.scene.children[this.gamepage.scene.children.length - 1]
-						.visible;
-			}
-			if (this.frame === 300) {
-				this.gamepage.scene.children[
-					this.gamepage.scene.children.length - 1
-				].visible = false;
-			}
-		}
-
-		// object destructuring
-		const { ball: ballData, paddle1, paddle2, score } = data;
-
-		this.gamepage.ballMesh.position.x = ballData.x;
-		this.gamepage.ballMesh.position.y = ballData.y;
-		this.gamepage.paddleMesh1.position.y = paddle1.y;
-		this.gamepage.paddleLightGroup1.position.y = paddle1.y;
-		this.gamepage.paddleMesh2.position.y = paddle2.y;
-		this.gamepage.paddleLightGroup2.position.y = paddle2.y;
-
-		if (Number(this.player1Score.textContent) !== score.player1) {
-			this.player1Score.classList.remove('score_transition');
-			void this.player1Score.offsetWidth;
-			this.player1Score.textContent = score.player1;
-			this.player1Score.classList.add('score_transition');
-		}
-		if (Number(this.player2Score.textContent) !== score.player2) {
-			this.player2Score.classList.remove('score_transition');
-			void this.player2Score.offsetWidth;
-			this.player2Score.textContent = score.player2;
-			this.player2Score.classList.add('score_transition');
-		}
-
-		this.gamepage.ballLight.position.copy(this.gamepage.ballMesh.position);
-
-		if (this.winner === 1) {
-			this.gamepage.camera.position.x = -4;
-			this.gamepage.camera.lookAt(this.gamepage.paddleMesh1.position);
-			this.gameResult.style.display = 'block';
-		}
-		if (this.winner === 2) {
-			this.gamepage.camera.position.x = 4;
-			this.gamepage.camera.lookAt(this.gamepage.paddleMesh2.position);
-			this.gameResult.style.display = 'block';
-		}
-
-		this.gamepage.renderer.render(this.gamepage.scene, this.gamepage.camera);
-	}
-
+	// -----------------------------------------------------------------------------
 	receiveMessages() {
 		this.ws.onmessage = (e) => {
 			const message = JSON.parse(e.data);
-			this.handleMessage(message);
+			this.messageManager.handleMessage(message);
 		};
-	}
-
-	handleMessage(message) {
-		switch (message.type) {
-			case 'game':
-				this.handleGameTypeMessage(message);
-				break;
-			case 'game_over':
-				console.log('game over');
-				if (message.subtype === 'tournament_tree') {
-					// eslint-disable-next-line no-param-reassign
-					message.data.Gamewebsocket = this;
-					// eslint-disable-next-line no-param-reassign
-					message.data.gameOver = true;
-					changeUrlData('tournament', message.data);
-				}
-				break;
-			case 'game_over_response':
-				// 최종 경기결과 정보 전송
-				// eslint-disable-next-line no-param-reassign
-				message.data.Gamewebsocket = this;
-				changeUrlData('tournamentResult', message.data);
-				break;
-
-			default:
-				console.log('default');
-				break;
-		}
-	}
-
-	handleGameTypeMessage(message) {
-		if (message.subtype === 'connection_established') {
-			this.send(gameSessionInfoMsg(this.initial));
-		} else if (message.subtype === 'tournament_tree') {
-			// eslint-disable-next-line no-param-reassign
-			message.data.Gamewebsocket = this;
-			changeUrlData('tournament', message.data);
-		} else if (message.subtype === 'match_init_setting') {
-			this.gamesetting = message.data;
-			// eslint-disable-next-line no-param-reassign
-			message.data.Gamewebsocket = this;
-			this.gamepage = new GamePage(message.data);
-			changeUrlInstance('game', this.gamepage);
-		} else if (message.subtype === 'match_run') {
-			this.renderThreeJs(message.data);
-		} else if (message.subtype === 'match_end') {
-			console.log('match_end');
-			if (this.gamesetting.battle_mode === 1) {
-				this.sendGameDisconnect();
-			} else {
-				// eslint-disable-next-line no-param-reassign
-				message.data.Gamewebsocket = this;
-			}
-			this.frame = 0;
-			removeModalBackdrop();
-			changeUrlData('duelstats', message.data);
-		} else if (message.subtype === 'error') {
-			console.log(`server: ${message.message}`);
-		}
 	}
 
 	addListeners() {

--- a/FE/src/websocket/MessageManager.js
+++ b/FE/src/websocket/MessageManager.js
@@ -33,7 +33,7 @@ export class MessageManager {
 		this.winner = 0;
 	}
 
-	// ----------------------------------------------------------
+	// -----------------------------------------------------------------------------
 
 	resetGameData() {
 		this.player1Score = document.querySelector('.player1');
@@ -43,7 +43,7 @@ export class MessageManager {
 		this.winner = 0;
 	}
 
-	// ----------------------------------------------------------
+	// -----------------------------------------------------------------------------
 
 	setGameSetting(data) {
 		this.gamesetting = data;
@@ -75,7 +75,7 @@ export class MessageManager {
 		console.log('disconnected');
 	}
 
-	// ----------------------------------------------------------
+	// -----------------------------------------------------------------------------
 
 	renderThreeJs(data) {
 		this.frame += 1;
@@ -171,7 +171,7 @@ export class MessageManager {
 		this.gamepage.renderer.render(this.gamepage.scene, this.gamepage.camera);
 	}
 
-	// ========================================================================
+	// =============================================================================
 
 	handleMessage(message) {
 		switch (message.type) {
@@ -203,6 +203,7 @@ export class MessageManager {
 				break;
 		}
 	}
+	// -----------------------------------------------------------------------------
 
 	handleGameTypeMessage(message) {
 		switch (message.subtype) {
@@ -239,19 +240,18 @@ export class MessageManager {
 				removeModalBackdrop(); // modal-fade 비활성화
 
 				// 1vs1 대전의 경우 disconnect
-				if (this.gamesetting.battle_mode === 1) {
+				if (this.gamesetting.battle_mode === 1)
 					changeUrlData('duelstats', {
 						...message.data,
 						sendMsg: this.sendGameDisconnect.bind(this)
 					});
-				}
 				// 토너먼트의 경우 다음 매치 요청
-				else {
+				else
 					changeUrlData('duelstats', {
 						...message.data,
 						sendMsg: this.sendGameNextMatch.bind(this)
 					});
-				}
+
 				break;
 			case SubType.ERROR:
 				console.log(`server: ${message.message}`);

--- a/FE/src/websocket/MessageManager.js
+++ b/FE/src/websocket/MessageManager.js
@@ -140,6 +140,7 @@ export class MessageManager {
 	}
 
 	displayWinner() {
+		if (this.winner === 0) return ;
 		const winnerPosition = this.winner === Winner.PLAYER_1 ? -4 : 4;
 		const targetPaddle =
 			this.winner === Winner.PLAYER_1

--- a/FE/src/websocket/MessageManager.js
+++ b/FE/src/websocket/MessageManager.js
@@ -1,0 +1,237 @@
+import { changeUrlInstance, changeUrlData } from '../index.js';
+import { removeModalBackdrop } from '../components/modal/modalUtiils.js';
+
+import * as msg from './messages.js';
+
+import GamePage from '../pages/GamePage.js';
+
+export class MessageManager {
+	constructor(websocket) {
+		this.websocket = websocket;
+
+		this.gamesetting = {};
+		this.gamepage = null;
+		this.player1Score = null;
+		this.player2Score = null;
+		this.gameResult = null;
+		this.frame = 0;
+		this.winner = 0;
+	}
+
+	// ----------------------------------------------------------
+	sendGameSessionInfo(data) {
+		this.websocket.send(msg.gameSessionInfoMsg(data));
+	}
+
+	sendGameMatchInitSetting() {
+		this.websocket.send(msg.gameMatchInitSettingMsg());
+	}
+
+	sendGameStartRequest() {
+		this.websocket.send(msg.gameStartRequestMsg());
+	}
+
+	sendGameNextMatch() {
+		this.websocket.send(msg.gameNextMatchMsg());
+	}
+
+	sendGameOver() {
+		this.websocket.send(msg.gameOverMsg());
+	}
+
+	sendGameDisconnect() {
+		const message = {
+			type: 'disconnect',
+			message: "I'm leaving!"
+		};
+		this.websocket.send(message);
+		this.websocket.close();
+		console.log('disconnected');
+	}
+
+	// ----------------------------------------------------------
+	renderThreeJs(data) {
+		this.frame += 1;
+		if (
+			Number(this.player1Score.textContent) ===
+			this.websocket.initial.total_score
+		) {
+			this.winner = 1;
+		}
+		if (
+			Number(this.player2Score.textContent) ===
+			this.websocket.initial.total_score
+		) {
+			this.winner = 2;
+		}
+
+		if (this.frame < 100) {
+			this.gamepage.camera.position.x = -4;
+			this.gamepage.camera.position.y = -1 + (this.frame / 100) * 2;
+			this.gamepage.camera.lookAt(this.gamepage.paddleMesh1.position);
+		}
+		if (this.frame >= 100 && this.frame < 200) {
+			this.gamepage.camera.position.x = 4;
+			this.gamepage.camera.position.y = 1 - ((this.frame - 100) / 100) * 2;
+			this.gamepage.camera.lookAt(this.gamepage.paddleMesh2.position);
+		}
+		if (this.frame >= 200 && this.frame <= 300) {
+			this.gamepage.camera.position.x = 0;
+			this.gamepage.camera.position.y = 0;
+			this.gamepage.camera.position.z =
+				3.5 +
+				Math.sin((3 / 2) * Math.PI + ((this.frame - 200) / 100) * Math.PI) *
+					(1 / 2);
+			this.gamepage.camera.lookAt(0, 0, 0);
+			if (this.frame === 200) {
+				this.gamepage.scene.children[
+					this.gamepage.scene.children.length - 1
+				].visible = true;
+			}
+			if (this.frame >= 275 && this.frame < 300 && this.frame % 4 === 0) {
+				this.gamepage.scene.children[
+					this.gamepage.scene.children.length - 1
+				].visible =
+					!this.gamepage.scene.children[this.gamepage.scene.children.length - 1]
+						.visible;
+			}
+			if (this.frame === 300) {
+				this.gamepage.scene.children[
+					this.gamepage.scene.children.length - 1
+				].visible = false;
+			}
+		}
+
+		// object destructuring
+		const { ball: ballData, paddle1, paddle2, score } = data;
+
+		this.gamepage.ballMesh.position.x = ballData.x;
+		this.gamepage.ballMesh.position.y = ballData.y;
+		this.gamepage.paddleMesh1.position.y = paddle1.y;
+		this.gamepage.paddleLightGroup1.position.y = paddle1.y;
+		this.gamepage.paddleMesh2.position.y = paddle2.y;
+		this.gamepage.paddleLightGroup2.position.y = paddle2.y;
+
+		if (Number(this.player1Score.textContent) !== score.player1) {
+			this.player1Score.classList.remove('score_transition');
+			// eslint-disable-next-line no-void
+			void this.player1Score.offsetWidth;
+			this.player1Score.textContent = score.player1;
+			this.player1Score.classList.add('score_transition');
+		}
+		if (Number(this.player2Score.textContent) !== score.player2) {
+			this.player2Score.classList.remove('score_transition');
+			// eslint-disable-next-line no-void
+			void this.player2Score.offsetWidth;
+			this.player2Score.textContent = score.player2;
+			this.player2Score.classList.add('score_transition');
+		}
+
+		this.gamepage.ballLight.position.copy(this.gamepage.ballMesh.position);
+
+		if (this.winner === 1) {
+			this.gamepage.camera.position.x = -4;
+			this.gamepage.camera.lookAt(this.gamepage.paddleMesh1.position);
+			this.gameResult.style.display = 'block';
+		}
+		if (this.winner === 2) {
+			this.gamepage.camera.position.x = 4;
+			this.gamepage.camera.lookAt(this.gamepage.paddleMesh2.position);
+			this.gameResult.style.display = 'block';
+		}
+
+		this.gamepage.renderer.render(this.gamepage.scene, this.gamepage.camera);
+	}
+
+	addListeners() {
+		this.player1Score = document.querySelector('.player1');
+		this.player2Score = document.querySelector('.player2');
+		this.gameResult = document.querySelector('.game-result');
+		this.winner = 0;
+	}
+
+	// ----------------------------------------------------------
+
+	handleMessage(message) {
+		switch (message.type) {
+			case 'game':
+				this.handleGameTypeMessage(message);
+				break;
+
+			case 'game_over':
+				console.log('game over');
+				if (message.subtype === 'tournament_tree') {
+					// 최종 대진표
+					changeUrlData('tournament', {
+						...message.data,
+						sendMsg: this.sendGameOver.bind(this)
+					});
+				}
+				break;
+			case 'game_over_response':
+				// 최종 경기결과 정보
+				{
+					const tmpData = {
+						content: message.data,
+						sendMsg: this.sendGameDisconnect.bind(this)
+					};
+					changeUrlData('tournamentResult', tmpData);
+				}
+				break;
+
+			default:
+				console.log('default');
+				break;
+		}
+	}
+
+	handleGameTypeMessage(message) {
+		if (message.subtype === 'connection_established') {
+			// 게임 초기 정보 전송
+			this.sendGameSessionInfo(this.websocket.initial);
+		} else if (message.subtype === 'tournament_tree') {
+			// 대진표 출력 및 게임 매치 초기화 요청
+			changeUrlData('tournament', {
+				...message.data,
+				sendMsg: this.sendGameMatchInitSetting.bind(this)
+			});
+		} else if (message.subtype === 'match_init_setting') {
+			// 매치 초기화 정보 수신
+			this.gamesetting = message.data;
+
+			// 게임 페이지 생성 및 실행
+			this.gamepage = new GamePage({
+				...message.data,
+				sendMsg: this.sendGameDisconnect.bind(this)
+			});
+			changeUrlInstance('game', this.gamepage);
+
+			// score 정보 초기화
+			this.addListeners();
+			// 게임 시작 요청
+			this.sendGameStartRequest();
+		} else if (message.subtype === 'match_run') {
+			// 매치 데이터 수신으로 rendering
+			this.renderThreeJs(message.data);
+		} else if (message.subtype === 'match_end') {
+			console.log('match_end');
+			this.frame = 0;
+			removeModalBackdrop(); // modal-fade 비활성화
+
+			// 1vs1 대전의 경우 disconnect 후 경기결과
+			if (this.gamesetting.battle_mode === 1) {
+				this.sendGameDisconnect();
+				changeUrlData('duelstats', message.data);
+			}
+			// 토너먼트의 경우 경기결과 출력 후 다음 매치 요청
+			else {
+				changeUrlData('duelstats', {
+					...message.data,
+					sendMsg: this.sendGameNextMatch.bind(this)
+				});
+			}
+		} else if (message.subtype === 'error') {
+			console.log(`server: ${message.message}`);
+		}
+	}
+}

--- a/FE/src/websocket/MessageManager.js
+++ b/FE/src/websocket/MessageManager.js
@@ -140,7 +140,7 @@ export class MessageManager {
 	}
 
 	displayWinner() {
-		if (this.winner === 0) return ;
+		if (this.winner === 0) return;
 		const winnerPosition = this.winner === Winner.PLAYER_1 ? -4 : 4;
 		const targetPaddle =
 			this.winner === Winner.PLAYER_1

--- a/FE/src/websocket/constWebsocket.js
+++ b/FE/src/websocket/constWebsocket.js
@@ -1,0 +1,22 @@
+export const MessageType = {
+	GAME: 'game',
+	GAME_OVER: 'game_over',
+	GAME_OVER_RESPONSE: 'game_over_response'
+};
+Object.freeze(MessageType);
+
+export const SubType = {
+	CONNECTION_ESTABLISHED: 'connection_established',
+	TOURNAMENT_TREE: 'tournament_tree',
+	MATCH_INIT_SETTING: 'match_init_setting',
+	MATCH_RUN: 'match_run',
+	MATCH_END: 'match_end',
+	ERROR: 'error'
+};
+Object.freeze(SubType);
+
+export const Winner = {
+	PLAYER_1: 1,
+	PLAYER_2: 2
+};
+Object.freeze(Winner);

--- a/FE/src/websocket/messages.js
+++ b/FE/src/websocket/messages.js
@@ -6,7 +6,7 @@ export function gameSessionInfoMsg(initial) {
 		data: initial
 	};
 	// 임시로 1로 설정
-	message.data.total_score = 1;
+	// message.data.total_score = 1;
 
 	return message;
 }

--- a/FE/src/websocket/messages.js
+++ b/FE/src/websocket/messages.js
@@ -4,7 +4,6 @@ export function gameSessionInfoMsg(initial) {
 		subtype: 'session_info',
 		message: '',
 		data: initial
-		// data: this.initial
 	};
 	// 임시로 1로 설정
 	message.data.total_score = 1;
@@ -49,6 +48,14 @@ export function gameOverMsg() {
 		type: 'game_over',
 		subtype: 'summary',
 		message: 'go!'
+	};
+	return message;
+}
+
+export function gameDisconnectMsg() {
+	const message = {
+		type: 'disconnect',
+		message: "I'm leaving!"
 	};
 	return message;
 }

--- a/FE/src/websocket/messages.js
+++ b/FE/src/websocket/messages.js
@@ -7,7 +7,7 @@ export function gameSessionInfoMsg(initial) {
 		// data: this.initial
 	};
 	// 임시로 1로 설정
-	// message.data.total_score = 1;
+	message.data.total_score = 1;
 
 	return message;
 }

--- a/FE/src/websocket/websocketUtils.js
+++ b/FE/src/websocket/websocketUtils.js
@@ -1,0 +1,54 @@
+export function gameSessionInfoMsg(initial) {
+	const message = {
+		type: 'game',
+		subtype: 'session_info',
+		message: '',
+		data: initial
+		// data: this.initial
+	};
+	// 임시로 1로 설정
+	// message.data.total_score = 1;
+
+	return message;
+}
+
+export function gameMatchInitSettingMsg() {
+	const message = {
+		type: 'game',
+		subtype: 'match_init_setting',
+		message: 'go!',
+		data: {}
+	};
+
+	return message;
+}
+
+export function gameStartRequestMsg() {
+	const message = {
+		type: 'game',
+		subtype: 'match_start',
+		message: 'go!',
+		data: '',
+		match_id: 123
+	};
+
+	return message;
+}
+
+export function gameNextMatchMsg() {
+	const message = {
+		type: 'game',
+		subtype: 'next_match',
+		message: 'go!'
+	};
+	return message;
+}
+
+export function gameOverMsg() {
+	const message = {
+		type: 'game_over',
+		subtype: 'summary',
+		message: 'go!'
+	};
+	return message;
+}


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

프론트 websocket 관련 부분 리팩토링

## 🧑‍💻 PR 세부 내용

### [ 기존 ] 

1. GameSettingPage에서 ‘완료’ 버튼을 클릭하면 `new Gamewebsocket()`을 통해 새로운 웹소켓을 생성

2. Gamewebsocket 의 constructor

    - `new Websocket()` 을 통해 게임 서버와 연결하고 멤버 변수를 초기화


    - websocket이 open 되었으면 ‘connected’ 출력 후 `receiveMessages()`를 통해 서버에서 온 메시지 수신 후 처리
3. receiveMessages()

    - switch/case를 통해 message.type에 따라 처리


    - changeUrlData를 통해 페이지를 이동한 후 서버에게 [웹소켓 통신 규약](https://www.notion.so/c5f34b0c42814439895971d70eacadd2)에 따른 응답을 보내기 위해 페이지로 웹소켓을 인자로 받아서 이용

### [ 문제점 ] 

1. changeUrlData를 통해 페이지를 이동한 후 서버에게 통신 규약에 따른 응답을 보내기 위해 페이지로 웹소켓을 인자로 받아감
    - Gamewebsocket.js
        
        ```jsx
        receiveMessages() {
        	...
                 else if (message.subtype === 'match_init_setting') {
        		message.data.Gamewebsocket = this;
        		changeUrlData('game', message.data);
        	} 
        	 ...
        }
        ```
        
    - gamePage.js
        
        ```jsx
        template() {
        	...
         	this.initial.Gamewebsocket.gamepage = this;
        	this.initial.Gamewebsocket.addListeners();
        	this.initial.Gamewebsocket.sendGameStartRequest();
        	...
        }
        
        ...
        returnButton.addEventListener('click', () => {
        	this.initial.Gamewebsocket.sendGameDisconnect();
        		
        });
        ...
        ```
        
    - Gamewebsocket과 gamePage가 서로 참조 하는 문제 발생
    
2. Gamewebsocket의 역할을 분리하고, 길이가 긴 함수들을 역할에 따라 분리할 필요가 있음

### [ 해결 ] 

1. 기존의 방식과 같이 GameSettingPage에서 ‘완료’ 버튼을 클릭하면 `new Gamewebsocket()`을 통해 새로운 웹소켓을 생성
2. Gamewebsocket
  - 사이트로부터 포트 번호를 받아와 웹소켓 생성
    
    ```jsx
    const { port } = location;
    this.ws = new WebSocket(`ws://localhost:${port}/ws/game-server/`);
    ```
    
  - constructor()
    - constructor()
        - new Websocket()
        - new MessageManager()
            - 메시지 관리
        - 멤버 변수 초기화
        - up/down key eventListeners 추가
        - receiveMessage() 로 메시지 수신
            - `messageManager.handleMessage(message)` 로 메시지를 전달하여 규약에 맞게 처리
            
3. MessageManager
    - switch/case문을 활용하여 message.type에 따라 처리
        
        ```jsx
        const MessageType = {
        	GAME: 'game',
        	GAME_OVER: 'game_over',
        	GAME_OVER_RESPONSE: 'game_over_response'
        };
        ```
        
    - message.type이 `‘game’`인 경우 message.subtype으로 구분하여 처리
        
        ```jsx
        const SubType = {
        	CONNECTION_ESTABLISHED: 'connection_established',
        	TOURNAMENT_TREE: 'tournament_tree',
        	MATCH_INIT_SETTING: 'match_init_setting',
        	MATCH_RUN: 'match_run',
        	MATCH_END: 'match_end',
        	ERROR: 'error'
        };
        ```
        

   - `changeUrlData`로 페이지를 이동할 경우 인자로 bind를 한 함수를 전달
    
     ‘tournament’ 페이지에서 event가 발생했을 경우 `sendMsg` 로 전달된 함수 실행
    
     - MessageManager.js
        
        ```jsx
        handleGameTypeMessage(message){
        	...
        	case SubType.TOURNAMENT_TREE:
        		// 대진표 출력 및 게임 매치 초기화 요청
        		changeUrlData('tournament', {
        			...message.data,
        			sendMsg: this.sendGameMatchInitSetting.bind(this)
        		});
        	...
        }
        ```
        
      - TournamentPage.js
        
        ```jsx
        const next = document.querySelector('.event-click-match');
        next.addEventListener('click', () => {
        	// 게임 매치 초기화 요청, MatchInitSettingMsg 전송
        	this.data.sendMsg();
        });
        ```
        

   - gamePage의 경우 서버에서 받아오는 정보를 직접 적용하기 위해, 멤버변수로 선언 후 `changeUrlInstance` 함수를 이용하여 페이지 이동
    
       ```jsx
       this.gamepage = new GamePage(…);
       changeUrlInstance('game', this.gamepage);
       ```
    
       이후 수신된 매치 데이터로 `renderThreeJs()` 에서 변경된 사항 threeJs로 rendering
    
   - 작성된 부분 이외에는  [웹소켓 통신 규약](https://www.notion.so/c5f34b0c42814439895971d70eacadd2)에 따라 서버로부터 메시지를 수신받고, 그에 따른 메시지 전송
  

5. renderThreeJs
    
    한 함수에 많은 코드가 담겨있어 용도에 맞게 함수로 분리
    
    - updateCameraPosition
        - 프레임에 맞게 camera position 변경 및 Ready 애니메이션 띄우기
    - checkWinner
        - 점수가 total_score에 도달했을 경우 winner 체크
    - updateScores
        - 플레이어의 점수 업데이트 및 득점한 플레이어의 점수에 효과 추가
    - displayWinner
        - 매치가 끝난 후 winner를 중심으로 camera 이동
       
6. messages.js  
    게임 서버에 보내는 메시지들을 함수로 분리하여 사용할 수 있도록 함


## 📸 스크린샷

없음

## 📚 관련 이슈

close #101 
