### PR TITLE
[Setting] Nginx와 백엔드 서버 연결

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
       - ./BE:/code
     env_file:
       - ./.env
+    environment:
+      POSTGRES_HOST: ${POSTGRES_DOCKER_HOST}
     networks:
       - pong_net
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -30,6 +30,19 @@ server {
 				proxy_set_header X-Forwarded-Proto $scheme;
 		}
 
+		location ~ ^/api/(.*)$ {
+				resolver 127.0.0.11;
+				proxy_pass http://backend:8000/$1;
+				proxy_http_version 1.1;
+
+				proxy_set_header Upgrade $http_upgrade;
+				proxy_set_header Connection "upgrade";
+				proxy_set_header Host $host;
+				proxy_set_header X-Real-IP $remote_addr;
+				proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+				proxy_set_header X-Forwarded-Proto $scheme;
+		}
+
 		error_page   500 502 503 504  /50x.html;
 		location = /50x.html {
 			root   /usr/share/nginx/html;


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

Nginx와 백엔드 서버 연결

## 🧑‍💻 PR 세부 내용

> [관련 개발 일지 링크](https://lowly-crepe-78b.notion.site/Nginx-67e2723fbd434bf9840d340465505c70?pvs=4)

- 백엔드 서버 라우팅을 위한 location 추가
- `/api/` 로 시작하는 경로인 경우 nginx가 백엔드 서버로 전달
- 백엔드에서 DB를 찾지 못해 환경변수 설정 추가
  - `docker-compose.yml`에 `environment` 활용
  - `env_file`보다 우선순위가 높음

## 📸 스크린샷

- postman에서는 csrftoken 값 설정이 필요하고 잘 설정했을 때 응답
<img width="300" alt="스크린샷 2024-04-03 오전 4 51 22" src="https://github.com/authenticity-house/ft_transcendence/assets/44529556/74a949f0-b58e-482c-a899-28b983e47d31">

- 브라우저에서 하면 css를 못찾는 이슈가 생김 (어짜피 개발용이라 상관 없을 듯)
<img width="700" alt="스크린샷 2024-04-03 오전 4 52 35" src="https://github.com/authenticity-house/ft_transcendence/assets/44529556/6e5c424e-0a12-4b80-b827-0ead1685ad17">


## 📚 관련 이슈

- close #124
