### PR TITLE
[Feat] 회원가입에 필요한 필드 중복 검사 API 구현

### DIFF
--- a/BE/users/urls.py
+++ b/BE/users/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path, include, re_path
-from .views import ConfirmEmailView, CustomRegisterView, FriendAPIView
+from .views import ConfirmEmailView, CustomRegisterView, FriendAPIView, CheckDuplicateAPIView
 
 urlpatterns = [
     path("", include("dj_rest_auth.urls")),
+    path("check/", CheckDuplicateAPIView.as_view(), name="check_field_duplicates"),
     # path("registration/", include("dj_rest_auth.registration.urls")),
     path("registration/", CustomRegisterView.as_view(), name="rest_register"),
     # 유저가 클릭한 이메일(=링크) 확인


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

회원가입에 필요한 필드 중복 검사 API 구현

## 🧑‍💻 PR 세부 내용

### GET `/users/check/` 요청 처리
- 이메일, 아이디, 닉네임을 쿼리 파라미터(`?`)로 받을 수 있음
  - 예시: `http://localhost:8000/users/check/?username=jeongmin&email=yesuel1111@naver.com`
  - 특정 필드 중 최소 1개 이상 존재해야 함
- 응답 결과
  - 모두 중복되지 않을 시 200
  - 중복된 값이 존재할 경우 409
  - 쿼리 파라미터가 존재하지 않을 포함 시 400
  - 허용되지 않은 쿼리 파라미터 포함 시 400
- `request.query_params`의 형태가 딕셔너리이지만 `value` 값이 배열 형태로 들어와서 `check_duplicate` 함수에서 `filter` 함수 사용 시 배열의 첫번째 값을 참조하도록 작성됨
- `filter`는 이전에 사용한 get과 달리 매칭되는 모든 값을 반환


## 📸 스크린샷

<img width="500" alt="Screen Shot 2024-04-09 at 11 16 01 PM" src="https://github.com/authenticity-house/ft_transcendence/assets/44529556/1b5fa421-b8aa-4e90-a012-12b23b7088d7">

## 📚 관련 이슈

- close #138 