### PR TITLE
[Setting] nginx.conf 파일에 CORS 에러 해결을 위한 헤더 추가

### DIFF
--- a/BE/users/adapters.py
+++ b/BE/users/adapters.py
@@ -20,5 +20,5 @@ class CustomUserAccountAdapter(DefaultAccountAdapter):
         Changing the confirmation URL to fit the domain that we are working on
         """
 
-        url = "http://localhost:8080/api/users/users-confirm-email/" + emailconfirmation.key + "/"
+        url = "http://127.0.0.1:8080/api/users/users-confirm-email/" + emailconfirmation.key + "/"
         return url

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,54 +1,60 @@
 server {
-		listen       80;
-		listen  [::]:80;
-		server_name  localhost;
+	listen       80;
+	listen  [::]:80;
+	server_name  localhost;
 
-		location /node_modules {
-				alias /usr/share/nginx/html/FE/node_modules/;
-		}
+	location /node_modules {
+		alias /usr/share/nginx/html/FE/node_modules/;
+	}
 
-		location /src {
+	location /src {
         alias /usr/share/nginx/html/FE/src/;
     }
 
     location / {
         alias /usr/share/nginx/html/FE/public/;
-				index  index.html;
-				try_files $uri $uri/ =404;
-				error_page 404 =301 /;
+		index  index.html;
+		try_files $uri $uri/ =404;
+		error_page 404 =301 /;
     }
 
-		location /ws/game-server/ {
-				proxy_pass http://game:8000;
-				proxy_http_version 1.1;
+	location /ws/game-server/ {
+		proxy_pass http://game:8000;
+		proxy_http_version 1.1;
 
-				proxy_set_header Upgrade $http_upgrade;
-				proxy_set_header Connection "upgrade";
-				proxy_set_header Host $http_host;
-				proxy_set_header X-Real-IP $remote_addr;
-				proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-				proxy_set_header X-Forwarded-Proto $scheme;
-				proxy_set_header Referer $http_referer;
-		}
+		proxy_set_header Upgrade $http_upgrade;
+		proxy_set_header Connection "upgrade";
+		proxy_set_header Host $http_host;
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_set_header X-Forwarded-Proto $scheme;
+		proxy_set_header Referer $http_referer;
+	}
 
-		location ~ ^/api/(.*)$ {
-				resolver 127.0.0.11;
-				proxy_pass http://backend:8000/$1;
-				proxy_http_version 1.1;
+	location ~ ^/api/(.*)$ {
+		resolver 127.0.0.11;
+		
+		add_header 'Access-Control-Allow-Origin' 'http://localhost:8080' always;
+		add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+		add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization' always;
+		add_header 'Access-Control-Allow-Credentials' 'true' always;
+		
+		proxy_pass http://backend:8000/$1;
+		proxy_http_version 1.1;
+		
+		proxy_set_header Upgrade $http_upgrade;
+		proxy_set_header Connection "upgrade";
+		proxy_set_header Host $http_host;
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_set_header X-Forwarded-Proto $scheme;
+		proxy_set_header Referer $http_referer;
+	}
 
-				proxy_set_header Upgrade $http_upgrade;
-				proxy_set_header Connection "upgrade";
-				proxy_set_header Host $http_host;
-				proxy_set_header X-Real-IP $remote_addr;
-				proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-				proxy_set_header X-Forwarded-Proto $scheme;
-				proxy_set_header Referer $http_referer;
-		}
-
-		error_page   500 502 503 504  /50x.html;
-		location = /50x.html {
-			root   /usr/share/nginx/html;
-		}
+	error_page   500 502 503 504  /50x.html;
+	location = /50x.html {
+		root   /usr/share/nginx/html;
+	}
 }
 
 map $http_upgrade $connection_upgrade {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -39,7 +39,7 @@ server {
 		add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization' always;
 		add_header 'Access-Control-Allow-Credentials' 'true' always;
 		
-		proxy_pass http://backend:8000/$1;
+		proxy_pass http://backend:8000/$1$is_args$args;
 		proxy_http_version 1.1;
 		
 		proxy_set_header Upgrade $http_upgrade;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,7 +1,7 @@
 server {
 	listen       80;
 	listen  [::]:80;
-	server_name  localhost;
+	server_name  127.0.0.1;
 
 	location /node_modules {
 		alias /usr/share/nginx/html/FE/node_modules/;
@@ -34,7 +34,7 @@ server {
 	location ~ ^/api/(.*)$ {
 		resolver 127.0.0.11;
 		
-		add_header 'Access-Control-Allow-Origin' 'http://localhost:8080' always;
+		add_header 'Access-Control-Allow-Origin' 'http://127.0.0.1:8080' always;
 		add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
 		add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization' always;
 		add_header 'Access-Control-Allow-Credentials' 'true' always;


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

nginx.conf 파일에 CORS 에러 해결을 위한 헤더 추가
nginx에서 백엔드로 요청 전송 시 쿼리 파라미터가 누락되는 문제 해결

## 🧑‍💻 PR 세부 내용

### nginx.conf 파일에 CORS 에러 해결을 위한 헤더 추가

이메일 인증을 위해 보낸 링크에서 로그인 시도할 때 CORS 에러가 발생하는 문제가 있었음
이때는 백엔드 링크로 접근해서 프론트로 리다이렉션 된 후 로그인을 시도하기 때문에 발생된다고 추정

- Access-Control-Allow-Origin 관련 헤더 추가
  - [CORS(Cross-Origin Resource Sharing)](https://developer.mozilla.org/en-US/docs/Glossary/CORS) 에러를 해결하기 위한 것
  - 이러한 헤더는 HTTP 프로토콜 규약에 정의된 옵션 (nginx라서 존재하는 것이 아님)
  - 브라우저와 백엔드 서버 사이에서 nginx가 HTTP 요청 및 응답을 전달하는 과정에서 발생
    >  [이 블로그](https://imprint.tistory.com/m/287)에서 설명하는 상황1과 유사함
- always 옵션: 모든 HTTP 응답 코드에 대해 이 헤더를 포함시키라는 지시

```
add_header 'Access-Control-Allow-Origin' 'http://localhost:8080' always;
add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization' always;
add_header 'Access-Control-Allow-Credentials' 'true' always;
``` 

- GPT 간략 설명
Access-Control-Allow-Origin: 서버가 자원에 접근할 수 있는 출처를 지정
Access-Control-Allow-Methods: HTTP 요청 메소드에 대한 접근을 제어하는 데 사용
Access-Control-Allow-Headers: 서버가 허용하는 헤더 목록을 지정
Access-Control-Allow-Credentials: 자격 증명(예: 쿠키, HTTP 인증)과 함께 요청을 할 때 사용

- 기타
  - nginx.conf 형식 맞추기 (탭 2칸을 모두 1칸으로 수정)

### nginx에서 백엔드로 요청 전송 시 쿼리 파라미터가 누락되는 문제 해결
- `$is_args`
  - 요청에 쿼리 스트링이 있는 경우 ?를 반환 / 그렇지 않은 경우 빈 문자열을 반환
  - 쿼리 스트링이 시작되는 지점을 나타내는 데 사용
- `$args`: 요청의 쿼리 스트링 전체를 포함
  - 존재하지 않을 경우 빈 문자열로 영향을 주지 않음

## 📸 스크린샷

<img width="300" alt="image" src="https://github.com/authenticity-house/ft_transcendence/assets/44529556/b3ca7939-d782-41fe-99fc-ce0feb913a6a">

## 📚 관련 이슈

- #135 
