### PR TITLE
[Feat] 유저 검색 및 특정 유저 프로필 조회 API 구현

### DIFF
--- a/BE/rooms/room_manager.py
+++ b/BE/rooms/room_manager.py
@@ -49,7 +49,7 @@ class RoomManager:
             "battle_mode": 1,
             "current_player": 1,
             "max_player": 2,
-            "rating": 1487
+            "rating": 1487,
         }
         test_room_info2 = {
             "room_number": 999,
@@ -57,7 +57,7 @@ class RoomManager:
             "battle_mode": 2,
             "current_player": 5,
             "max_player": 7,
-            "rating": 2398
+            "rating": 2398,
         }
         lst = [test_room_info1, test_room_info2]
         for room in cls._rooms.values():

--- a/BE/rooms/room_manager.py
+++ b/BE/rooms/room_manager.py
@@ -49,7 +49,7 @@ class RoomManager:
             "battle_mode": 1,
             "current_headcount": 1,
             "max_headcount": 2,
-            "rating": 1487
+            "rating": 1487,
         }
         test_room_info2 = {
             "room_number": 999,
@@ -57,7 +57,7 @@ class RoomManager:
             "battle_mode": 2,
             "current_headcount": 5,
             "max_headcount": 7,
-            "rating": 2398
+            "rating": 2398,
         }
         lst = [test_room_info1, test_room_info2]
         for room in cls._rooms.values():

--- a/BE/users/serializers.py
+++ b/BE/users/serializers.py
@@ -33,7 +33,7 @@ class CustomUserDetailsSerializer(serializers.ModelSerializer):
         read_only_fields = ("pk", "username", "provider")
 
 
-class FriendshipSerializer(serializers.ModelSerializer):
+class UserProfileSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ("pk", "nickname", "profile_url")

--- a/BE/users/urls.py
+++ b/BE/users/urls.py
@@ -4,7 +4,7 @@ from .views import (
     CustomRegisterView,
     FriendAPIView,
     CheckDuplicateAPIView,
-    UserPrefixSearchView,
+    UserPrefixSearchView, UserDetailView,
 )
 
 urlpatterns = [
@@ -20,4 +20,5 @@ urlpatterns = [
     ),
     path("friends/", FriendAPIView.as_view(), name="friends"),
     path("search/", UserPrefixSearchView.as_view(), name="search_user_with_nickname_prefix"),
+    # path("detail/{pk}/", UserDetailView.as_view(), name="another_user_detail"),
 ]

--- a/BE/users/urls.py
+++ b/BE/users/urls.py
@@ -1,5 +1,11 @@
 from django.urls import path, include, re_path
-from .views import ConfirmEmailView, CustomRegisterView, FriendAPIView, CheckDuplicateAPIView
+from .views import (
+    ConfirmEmailView,
+    CustomRegisterView,
+    FriendAPIView,
+    CheckDuplicateAPIView,
+    UserPrefixSearchView,
+)
 
 urlpatterns = [
     path("", include("dj_rest_auth.urls")),
@@ -13,4 +19,5 @@ urlpatterns = [
         name="account_confirm_email",
     ),
     path("friends/", FriendAPIView.as_view(), name="friends"),
+    path("search/", UserPrefixSearchView.as_view(), name="search_user_with_nickname_prefix"),
 ]

--- a/BE/users/urls.py
+++ b/BE/users/urls.py
@@ -4,7 +4,8 @@ from .views import (
     CustomRegisterView,
     FriendAPIView,
     CheckDuplicateAPIView,
-    UserPrefixSearchView, UserDetailView,
+    UserPrefixSearchView,
+    UserProfileView,
 )
 
 urlpatterns = [
@@ -20,5 +21,5 @@ urlpatterns = [
     ),
     path("friends/", FriendAPIView.as_view(), name="friends"),
     path("search/", UserPrefixSearchView.as_view(), name="search_user_with_nickname_prefix"),
-    # path("detail/{pk}/", UserDetailView.as_view(), name="another_user_detail"),
+    path("detail/<int:user_pk>/", UserProfileView.as_view(), name="another_user_profile"),
 ]

--- a/BE/users/views.py
+++ b/BE/users/views.py
@@ -15,7 +15,7 @@ from allauth.account.utils import send_email_confirmation
 from dj_rest_auth.registration.views import RegisterView
 
 from users.models import User
-from users.serializers import FriendshipSerializer
+from users.serializers import UserProfileSerializer
 
 
 class ConfirmEmailView(APIView):
@@ -92,7 +92,7 @@ class FriendAPIView(APIView):
 
         try:
             user_profile = User.objects.get(pk=user_pk)
-            serializer = FriendshipSerializer(user_profile.friends.all(), many=True)
+            serializer = UserProfileSerializer(user_profile.friends.all(), many=True)
             return Response(serializer.data)
         except ObjectDoesNotExist as exc:
             raise NotFound(detail=f"User does not exist: pk={user_pk}") from exc

--- a/BE/users/views.py
+++ b/BE/users/views.py
@@ -168,3 +168,12 @@ class UserPrefixSearchView(APIView):
         user_profile_list = User.objects.filter(nickname__startswith=prefix)
         serializer = UserProfileSerializer(user_profile_list, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+# class UserDetailView(APIView):
+#     authentication_classes = [SessionAuthentication]
+#     permission_classes = [IsAuthenticated]
+#
+    # def get(self, request, pk):
+    #     print(pk)
+    #     return Response(pk)

--- a/BE/users/views.py
+++ b/BE/users/views.py
@@ -170,10 +170,14 @@ class UserPrefixSearchView(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
-# class UserDetailView(APIView):
-#     authentication_classes = [SessionAuthentication]
-#     permission_classes = [IsAuthenticated]
-#
-    # def get(self, request, pk):
-    #     print(pk)
-    #     return Response(pk)
+class UserProfileView(APIView):
+    authentication_classes = [SessionAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, user_pk):
+        try:
+            user_profile = User.objects.get(pk=user_pk)
+            serializer = UserProfileSerializer(user_profile)
+            return Response(serializer.data)
+        except ObjectDoesNotExist as exc:
+            raise NotFound(detail=f"User does not exist: pk={user_pk}") from exc

--- a/BE/users/views.py
+++ b/BE/users/views.py
@@ -166,8 +166,11 @@ class UserPrefixSearchView(APIView):
         prefix = query_params["prefix"]
 
         user_profile_list = User.objects.filter(nickname__startswith=prefix)
-        serializer = UserProfileSerializer(user_profile_list, many=True)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        if user_profile_list.exists():
+            serializer = UserProfileSerializer(user_profile_list, many=True)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
 
 
 class UserProfileView(APIView):

--- a/BE/users/views.py
+++ b/BE/users/views.py
@@ -164,6 +164,8 @@ class UserPrefixSearchView(APIView):
             raise InvalidQueryParams("'prefix'")
 
         prefix = query_params["prefix"]
+        if prefix == "":
+            raise ParseError(detail="prefix value is empty")
 
         user_profile_list = User.objects.filter(nickname__startswith=prefix)
         if user_profile_list.exists():


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

- 특정 접두사로 시작하는 닉네임을 가진 유저 검색 API 구현
- 특정 pk를 가진 유저 프로필 조회 API 구현

## 🧑‍💻 PR 세부 내용

### 특정 접두사로 시작하는 닉네임을 가진 유저 검색 API 구현
- `GET` `/users/search/?prefix=abc`
- 로그인시에만 동작
- DB에서 접두사로 시작하는 닉네임을 가진 매칭되는 모든 유저 리스트를 반환
  `user_profile_list = User.objects.filter(nickname__startswith=prefix)`
- 200 OK (성공)
- - 400 Bad Request (잘못된 요청)
  - 쿼리 파라미터에 `prefix`가 포함되지 않은 경우
- 403 Forbidden (로그인 하지 않고 요청 시)

### 특정 pk를 가진 유저 프로필 조회 API 구현
- `GET` `/users/detail/<user_pk>`
- 로그인시에만 동작
- DB에서 pk에 해당하는 유저 프로필 반환
  `user_profile = User.objects.get(pk=user_pk)`
- 프로필은 해당 유저의 pk, profile_url, nickname을 포함
  - 추후 경기 요약 정보는 따로 API 구현 예정
- pk는 DB에서 자동으로 늘어나는 인덱스값(username(id)가 아님)
- 200 OK (성공)
- 404 Bad Request (잘못된 요청)
  - 해당하는 pk를 가진 유저가 존재하지 않는 경우
  - pk가 숫자가 아니라면 url이 매칭되지 않음
- 403 Forbidden (로그인 하지 않고 요청 시)


## 📸 스크린샷

<img width="627" alt="Screen Shot 2024-04-12 at 6 18 16 PM" src="https://github.com/authenticity-house/ft_transcendence/assets/44529556/54c2ea4b-c1c9-4bce-a4f2-a0c3bc593ec2">

<img width="611" alt="Screen Shot 2024-04-12 at 6 17 57 PM" src="https://github.com/authenticity-house/ft_transcendence/assets/44529556/15c64b25-c4c5-4f31-ba1a-96fdcfef339c">



## 📚 관련 이슈

- #146
