### PR TITLE
[Bug] canvas 중복 문제 해결

### DIFF
--- a/FE/public/css/styles.css
+++ b/FE/public/css/styles.css
@@ -1022,6 +1022,13 @@ td {
 	height: 45rem;
 }
 
+.unique-graph-container {
+	display: flex;
+	justify-content: space-between;
+	width: 100%;
+	height: 45rem;
+}
+
 /* Graph - ScoreTrend */
 .score-trend-container {
 	display: flex;
@@ -1056,6 +1063,16 @@ td {
 	padding: 2rem 0;
 }
 
+.unique-score-trend-canvas-text-container {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: space-between;
+	width: 4rem;
+	height: 100%;
+	padding: 2rem 0;
+}
+
 .score-trend-canvas-text-wrapper {
 	display: flex;
 	justify-content: end;
@@ -1066,7 +1083,22 @@ td {
 	margin: auto;
 }
 
+.unique-score-trend-canvas-text-wrapper {
+	display: flex;
+	justify-content: end;
+	align-items: center;
+	height: auto;
+	width: 3em;
+	padding-right: 1rem;
+	margin: auto;
+}
+
 .score-trend-canvas-draw-container {
+	border-left: 0.2rem solid white;
+	border-bottom: 0.2rem solid white;
+}
+
+.unique-score-trend-canvas-draw-container {
 	border-left: 0.2rem solid white;
 	border-bottom: 0.2rem solid white;
 }
@@ -1122,6 +1154,10 @@ td {
 }
 
 .score-position-canvas {
+	border: 0.2rem solid white;
+}
+
+.unique-score-position-canvas {
 	border: 0.2rem solid white;
 }
 

--- a/FE/src/components/DuelGraphStats.js
+++ b/FE/src/components/DuelGraphStats.js
@@ -1,13 +1,19 @@
 const html = String.raw;
 
 class DuelGraphStats {
-	static getScoreTrendHTML(matchData) {
+	static getScoreTrendHTML(matchData, unique) {
+		const uniqueText = unique ? 'unique-' : '';
+
 		return html`
 			<div class="score-trend-container">
 				<div class="score-trend-title display-light24">득점 추이</div>
 				<div class="score-trend-canvas-container">
-					<div class="score-trend-canvas-text-container display-light10"></div>
-					<canvas class="score-trend-canvas-draw-container"></canvas>
+					<div
+						class="${uniqueText}score-trend-canvas-text-container display-light10"
+					></div>
+					<canvas
+						class="${uniqueText}score-trend-canvas-draw-container"
+					></canvas>
 				</div>
 				<div class="score-trend-player-name-container display-light16">
 					<div class="score-trend-player-name-wrapper">
@@ -27,11 +33,13 @@ class DuelGraphStats {
 		`;
 	}
 
-	static getScorePositionHTML(matchData) {
+	static getScorePositionHTML(matchData, unique) {
+		const uniqueText = unique ? 'unique-' : '';
+
 		return html`
 			<div class="score-position-container">
 				<div class="score-position-title display-light24">득점 위치</div>
-				<canvas class="score-position-canvas"></canvas>
+				<canvas class="${uniqueText}score-position-canvas"></canvas>
 				<div class="score-position-player-name-container display-light16">
 					<div class="score-position-player-left-wrapper">
 						<div class="score-player-name-margin-right">
@@ -50,14 +58,19 @@ class DuelGraphStats {
 		`;
 	}
 
-	static appendScoresToYAxis(maxScore, graphContainer) {
+	static appendScoresToYAxis(maxScore, graphContainer, unique) {
+		const uniqueText = unique ? 'unique-' : '';
 		const scoreText = graphContainer
-			? graphContainer.querySelector('.score-trend-canvas-text-container')
-			: document.querySelector('.score-trend-canvas-text-container');
+			? graphContainer.querySelector(
+					`.${uniqueText}score-trend-canvas-text-container`
+				)
+			: document.querySelector(
+					`.${uniqueText}score-trend-canvas-text-container`
+				);
 
 		let scoreTextWrappers = '';
 		for (let score = maxScore; score >= 0; score -= 1) {
-			scoreTextWrappers += `<div class="score-trend-canvas-text-wrapper">${score}</div>`;
+			scoreTextWrappers += `<div class="${uniqueText}score-trend-canvas-text-wrapper">${score}</div>`;
 		}
 		const htmlString = html`${scoreTextWrappers}`;
 		const fragment = document
@@ -66,18 +79,27 @@ class DuelGraphStats {
 		scoreText.appendChild(fragment);
 	}
 
-	static getScoreTextPosition(graphContainer) {
+	static getScoreTextPosition(graphContainer, unique) {
+		const uniqueText = unique ? 'unique-' : '';
 		const scoreParent = graphContainer
-			? graphContainer.querySelector('.score-trend-canvas-text-container')
-			: document.querySelector('.score-trend-canvas-text-container');
+			? graphContainer.querySelector(
+					`.${uniqueText}score-trend-canvas-text-container`
+				)
+			: document.querySelector(
+					`.${uniqueText}score-trend-canvas-text-container`
+				);
 		const scoreParentRect = scoreParent.getBoundingClientRect();
 		const parentY = scoreParentRect.y;
 		const position = [];
 
 		let halfHeight;
 		const scoreTextWrappers = graphContainer
-			? graphContainer.querySelectorAll('.score-trend-canvas-text-wrapper')
-			: document.querySelectorAll('.score-trend-canvas-text-wrapper');
+			? graphContainer.querySelectorAll(
+					`.${uniqueText}score-trend-canvas-text-wrapper`
+				)
+			: document.querySelectorAll(
+					`.${uniqueText}score-trend-canvas-text-wrapper`
+				);
 		scoreTextWrappers.forEach((child) => {
 			const childRect = child.getBoundingClientRect();
 			halfHeight = childRect.height / 2;
@@ -142,12 +164,18 @@ class DuelGraphStats {
 	static appendScoreTrendGraph(
 		leftScoreTrend,
 		rightScoreTrend,
-		graphContainer
+		graphContainer,
+		unique
 	) {
-		const position = this.getScoreTextPosition(graphContainer);
+		const position = this.getScoreTextPosition(graphContainer, unique);
+		const uniqueText = unique ? 'unique-' : '';
 		const canvas = graphContainer
-			? graphContainer.querySelector('.score-trend-canvas-draw-container')
-			: document.querySelector('.score-trend-canvas-draw-container');
+			? graphContainer.querySelector(
+					`.${uniqueText}score-trend-canvas-draw-container`
+				)
+			: document.querySelector(
+					`.${uniqueText}score-trend-canvas-draw-container`
+				);
 
 		// canvas : 33.5rem , 36rem
 		const [responsiveWidth, reponsiveHeight] = this.getWidthHeight(33.5, 36);
@@ -190,10 +218,17 @@ class DuelGraphStats {
 		ctx.closePath();
 	}
 
-	static appendScorePositionGraph(leftPosition, rightPosition, graphContainer) {
+	static appendScorePositionGraph(
+		leftPosition,
+		rightPosition,
+		graphContainer,
+		unique
+	) {
+		const uniqueText = unique ? 'unique-' : '';
+
 		const canvas = graphContainer
-			? graphContainer.querySelector('.score-position-canvas')
-			: document.querySelector('.score-position-canvas');
+			? graphContainer.querySelector(`.${uniqueText}score-position-canvas`)
+			: document.querySelector(`.${uniqueText}score-position-canvas`);
 		// canvas : 28rem, 35.6rem
 		const [responsiveWidth, reponsiveHeight] = this.getWidthHeight(33.5, 36);
 		canvas.width = responsiveWidth;

--- a/FE/src/components/DuelReport.js
+++ b/FE/src/components/DuelReport.js
@@ -39,15 +39,19 @@ function duelCollapseElement(
 	matchRallyHtml,
 	specialStatsHtml,
 	scoreTrendHtml,
-	scorePositionHtml
+	scorePositionHtml,
+	unique
 ) {
+	const uniqueText = unique ? 'unique-' : '';
 	return html`
 		<div class="divider"></div>
 		<div class="basic-stats-container display-light18">${matchRallyHtml}</div>
 		<div class="divider"></div>
 		${specialStatsHtml}
 		<div class="divider"></div>
-		<div class="graph-container">${scoreTrendHtml} ${scorePositionHtml}</div>
+		<div class="${uniqueText}graph-container">
+			${scoreTrendHtml} ${scorePositionHtml}
+		</div>
 	`;
 }
 
@@ -56,7 +60,8 @@ function duelReportWrapper(
 	matchRallyHtml,
 	specialStatsHtml,
 	scoreTrendHtml,
-	scorePositionHtml
+	scorePositionHtml,
+	unique
 ) {
 	const resultElement = duelResultElement(data);
 	const dataTimeElement = duelDateTimeElement(data);
@@ -64,7 +69,8 @@ function duelReportWrapper(
 		matchRallyHtml,
 		specialStatsHtml,
 		scoreTrendHtml,
-		scorePositionHtml
+		scorePositionHtml,
+		unique
 	);
 
 	return html`

--- a/FE/src/constants/apiConfig.js
+++ b/FE/src/constants/apiConfig.js
@@ -13,7 +13,7 @@ function getApiEndpoints() {
 		LOGIN_URL: `${USERS_URL}login/`,
 		REGISTRATION_URL: `${USERS_URL}registration/`,
 		LOGOUT_URL: `${USERS_URL}logout/`,
-		REGISTER_CHECK_URL: `${USERS_URL}check/?`
+		REGISTER_CHECK_URL: `${USERS_URL}check/?`,
 		ROOMS_URL: `${ROOMS_URL}`
 	};
 }

--- a/FE/src/pages/DuelStatsPage.js
+++ b/FE/src/pages/DuelStatsPage.js
@@ -20,8 +20,11 @@ class DuelStatsPage {
 		const matchDateTimeHtml = DuelBasicStats.getMatchDateTimeHTML(matchData);
 		const matchRallyHtml = DuelBasicStats.getMatchRallyHTML(matchData);
 		const specialStatsHtml = DuelSpecialStats.getSpecialStatsHTML(matchData);
-		const scoreTrendHtml = DuelGraphStats.getScoreTrendHTML(matchData);
-		const scorePositionHtml = DuelGraphStats.getScorePositionHTML(matchData);
+		const scoreTrendHtml = DuelGraphStats.getScoreTrendHTML(matchData, true);
+		const scorePositionHtml = DuelGraphStats.getScorePositionHTML(
+			matchData,
+			true
+		);
 		const nextButton = new ButtonSmall('다음');
 
 		return html`
@@ -50,15 +53,19 @@ class DuelStatsPage {
 	mount(data) {
 		const matchData = DuelStatsData.getMountDuelStatsData(data);
 		// score-trend
-		DuelGraphStats.appendScoresToYAxis(matchData.maxScore);
+		DuelGraphStats.appendScoresToYAxis(matchData.maxScore, false, true);
 		DuelGraphStats.appendScoreTrendGraph(
 			matchData.leftScoreTrend,
-			matchData.rightScoreTrend
+			matchData.rightScoreTrend,
+			false,
+			true
 		);
 		// score-position
 		DuelGraphStats.appendScorePositionGraph(
 			matchData.leftPosition,
-			matchData.rightPosition
+			matchData.rightPosition,
+			false,
+			true
 		);
 	}
 

--- a/FE/src/pages/TournamentResultPage.js
+++ b/FE/src/pages/TournamentResultPage.js
@@ -24,15 +24,19 @@ class TournamentResultPage {
 			const resultData = DuelStatsData.getDuelStatsData(content[i]);
 			const matchRallyHtml = DuelBasicStats.getMatchRallyHTML(resultData);
 			const specialStatsHtml = DuelSpecialStats.getSpecialStatsHTML(resultData);
-			const scoreTrendHtml = DuelGraphStats.getScoreTrendHTML(resultData);
-			const scorePositionHtml = DuelGraphStats.getScorePositionHTML(resultData);
+			const scoreTrendHtml = DuelGraphStats.getScoreTrendHTML(resultData, true);
+			const scorePositionHtml = DuelGraphStats.getScorePositionHTML(
+				resultData,
+				true
+			);
 
 			duelReports += duelReportWrapper(
 				resultData,
 				matchRallyHtml,
 				specialStatsHtml,
 				scoreTrendHtml,
-				scorePositionHtml
+				scorePositionHtml,
+				true
 			);
 		}
 
@@ -56,22 +60,29 @@ class TournamentResultPage {
 			'.duel-report-container'
 		);
 
-		const graphContainers =
-			duelReportContainer.querySelectorAll('.graph-container');
+		const graphContainers = duelReportContainer.querySelectorAll(
+			'.unique-graph-container'
+		);
 		graphContainers.forEach((graphContainer) => {
 			const matchData = DuelStatsData.getMountDuelStatsData(content[i]);
 			// score-trend
-			DuelGraphStats.appendScoresToYAxis(matchData.maxScore, graphContainer);
+			DuelGraphStats.appendScoresToYAxis(
+				matchData.maxScore,
+				graphContainer,
+				true
+			);
 			DuelGraphStats.appendScoreTrendGraph(
 				matchData.leftScoreTrend,
 				matchData.rightScoreTrend,
-				graphContainer
+				graphContainer,
+				true
 			);
 			// score-position
 			DuelGraphStats.appendScorePositionGraph(
 				matchData.leftPosition,
 				matchData.rightPosition,
-				graphContainer
+				graphContainer,
+				true
 			);
 			i += 1;
 		});


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 모달-경기기록 그래프 canvas와 토너먼트 or 1vs1 결과 페이지 그래프 canvas 중복현상 해결

## 🧑‍💻 PR 세부 내용

### 버그 상황
1. 모달의 경기 기록을 누르고 난 뒤, 토너먼트나 1vs1 대결을 진행
2. 게임이 끝난 후, 토너먼트-전체경기결과페이지 / 1vs1-경기결과 페이지에서 그래프 UI 를 그릴 때 오류 발생
### 버그 원인
- 모달을 생성하면서 기존에 있었던 코드들과 충돌이 나는 현상입니다.
- 모달에서 활용했던 똑같은 그래프 코드를 사용하기에 querySelector(), querySelectorAll() 함수에서 모달의 그래프 코드를 참조하는 오류가 발생합니다.
### 해결 방안
- 토너먼트-경기결과페이지 or 1vs1 경기결과 페이지에서의 클래스 이름을 변경하여 모달에서 사용한 그래프 코드의 클래스이름과 겹치지 않도록 합니다.
## 📸 스크린샷
생략
## 📚 관련 이슈
#154