### PR TITLE
[Feat] 방 기능 추가(상태 변경, 방 정보 수정, 방 자동 삭제)

### DIFF
--- a/BE/rooms/services/room.py
+++ b/BE/rooms/services/room.py
@@ -105,6 +105,7 @@ class Room:  # pylint: disable=R0902
         for room_user in self._users:
             if room_user.is_same(user):
                 room_user.change_ready_state()
+                break
 
     def change_info(self, info):
         self._level = info["level"]

--- a/BE/rooms/services/room.py
+++ b/BE/rooms/services/room.py
@@ -98,6 +98,10 @@ class Room:  # pylint: disable=R0902
 
         raise RoomError(f"Can not found such user: {user.nickname}")
 
+    def is_host(self, user) -> bool:
+        host_user = self._users[0]
+        return host_user._nickname == user.nickname
+
     def __current_headcount(self) -> int:
         return len(self._users)
 

--- a/BE/rooms/services/room.py
+++ b/BE/rooms/services/room.py
@@ -47,17 +47,16 @@ class Room:  # pylint: disable=R0902
         self._total_rating += rating
 
     def delete_user(self, user) -> None:
-        nickname = user.nickname
         # rating = user.stats.rating
         rating = 1000
 
         for idx, room_user in enumerate(self._users):
-            if room_user._nickname == nickname:
+            if room_user.is_same(user):
                 self._users.pop(idx)
                 self._total_rating -= rating
                 return
 
-        raise RoomError(f"Can not found such user: {nickname}")
+        raise RoomError(f"Can not found such user: {user.nickname}")
 
     def room_info(self) -> dict:
         return {
@@ -90,7 +89,7 @@ class Room:  # pylint: disable=R0902
 
     def my_info(self, user) -> dict:
         for idx, room_user in enumerate(self._users):
-            if room_user._nickname == user.nickname:
+            if room_user.is_same(user):
                 info = room_user.info()
                 info["host"] = idx == 0
                 info["room_position"] = idx
@@ -100,11 +99,11 @@ class Room:  # pylint: disable=R0902
 
     def is_host(self, user) -> bool:
         host_user = self._users[0]
-        return host_user._nickname == user.nickname
+        return host_user.is_same(user)
 
     def change_state(self, user):
         for room_user in self._users:
-            if user.nickname == room_user._nickname:
+            if room_user.is_same(user):
                 room_user.change_ready_state()
 
     def change_info(self, info):

--- a/BE/rooms/services/room.py
+++ b/BE/rooms/services/room.py
@@ -107,6 +107,12 @@ class Room:  # pylint: disable=R0902
             if user.nickname == room_user._nickname:
                 room_user.change_ready_state()
 
+    def change_info(self, info):
+        self._level = info["level"]
+        self._total_score = info["total_score"]
+        self._paddle_color = info["color"]["paddle"]
+        self._ball_color = info["color"]["ball"]
+
     def __current_headcount(self) -> int:
         return len(self._users)
 

--- a/BE/rooms/services/room.py
+++ b/BE/rooms/services/room.py
@@ -102,6 +102,11 @@ class Room:  # pylint: disable=R0902
         host_user = self._users[0]
         return host_user._nickname == user.nickname
 
+    def change_state(self, user):
+        for room_user in self._users:
+            if user.nickname == room_user._nickname:
+                room_user.change_ready_state()
+
     def __current_headcount(self) -> int:
         return len(self._users)
 

--- a/BE/rooms/services/room_manager.py
+++ b/BE/rooms/services/room_manager.py
@@ -64,7 +64,7 @@ class RoomManager:
         info = {
             "room_info": room.room_info(),
             "user_info": room.users_info(),
-            "my_info": room.my_info(user)
+            "my_info": room.my_info(user),
         }
         return info
 

--- a/BE/rooms/services/room_manager.py
+++ b/BE/rooms/services/room_manager.py
@@ -42,6 +42,15 @@ class RoomManager:
         room.add_user(user)
 
     @classmethod
+    def delete_room(cls, room_number) -> None:
+        cls._rooms.pop(room_number)
+
+    @classmethod
+    def is_host(cls, room_number, user) -> bool:
+        room = cls.get_room(room_number)
+        return room.is_host(user)
+
+    @classmethod
     def room_list(cls) -> list:
         lst = []
         for room in cls._rooms.values():

--- a/BE/rooms/services/room_user.py
+++ b/BE/rooms/services/room_user.py
@@ -26,3 +26,6 @@ class RoomUser:
             "rating": self._rating,
             "ready_state": self._ready_state == RoomUser.Status.READY,
         }
+
+    def is_same(self, user) -> bool:
+        return self._nickname == user.nickname

--- a/BE/websocket/room_consumer.py
+++ b/BE/websocket/room_consumer.py
@@ -30,6 +30,8 @@ class RoomConsumer(JsonWebsocketConsumer):
         msg_body = content.get("data", "")
         if msg_type == "room.exit":
             self.room_exit()
+        elif msg_type == "room.change.state":
+            self.change_state()
 
     def room_exit(self):
         room = self.__get_room()
@@ -54,6 +56,11 @@ class RoomConsumer(JsonWebsocketConsumer):
         info = RoomManager.room_info(self.room_number, self.user)
         info["type"] = "room.info"
         self.send_json(info)
+
+    def change_state(self):
+        room = self.__get_room()
+        room.change_state(self.user)
+        self.broadcast("room.info", "get room info")
 
     def broadcast(self, msg_type, msg_body):
         async_to_sync(self.channel_layer.group_send)(

--- a/BE/websocket/room_consumer.py
+++ b/BE/websocket/room_consumer.py
@@ -48,15 +48,15 @@ class RoomConsumer(JsonWebsocketConsumer):
         self.broadcast("room.info", "get room info")
         self.close()
 
-    def room_end(self, event):
+    def room_end(self, event):  # pylint: disable=unused-argument
         msg = {"type": "room.end"}
         self.send_json(msg)
         self.close()
 
-    def room_info(self, event):
+    def room_info(self, event):  # pylint: disable=unused-argument
         try:
             info = RoomManager.room_info(self.room_number, self.user)
-        except RoomError as e:
+        except RoomError:
             return
         info["type"] = "room.info"
         self.send_json(info)

--- a/BE/websocket/room_consumer.py
+++ b/BE/websocket/room_consumer.py
@@ -32,6 +32,8 @@ class RoomConsumer(JsonWebsocketConsumer):
             self.room_exit()
         elif msg_type == "room.change.state":
             self.change_state()
+        elif msg_type == "room.change.info":
+            self.change_info(msg_body)
 
     def room_exit(self):
         room = self.__get_room()
@@ -60,6 +62,11 @@ class RoomConsumer(JsonWebsocketConsumer):
     def change_state(self):
         room = self.__get_room()
         room.change_state(self.user)
+        self.broadcast("room.info", "get room info")
+
+    def change_info(self, data):
+        room = self.__get_room()
+        room.change_info(data)
         self.broadcast("room.info", "get room info")
 
     def broadcast(self, msg_type, msg_body):

--- a/BE/websocket/room_consumer.py
+++ b/BE/websocket/room_consumer.py
@@ -33,8 +33,21 @@ class RoomConsumer(JsonWebsocketConsumer):
 
     def room_exit(self):
         room = self.__get_room()
+        if RoomManager.is_host(self.room_number, self.user):
+            self.broadcast("room.end", "get room info")
+            RoomManager.delete_room(self.room_number)
+            self.close()
+            return
+
         room.delete_user(self.user)
         self.broadcast("room.info", "get room info")
+        self.close()
+
+    def room_end(self, event):
+        msg = {
+            "type": "room.end"
+        }
+        self.send_json(msg)
         self.close()
 
     def room_info(self, event):

--- a/BE/websocket/room_consumer.py
+++ b/BE/websocket/room_consumer.py
@@ -48,9 +48,7 @@ class RoomConsumer(JsonWebsocketConsumer):
         self.close()
 
     def room_end(self, event):
-        msg = {
-            "type": "room.end"
-        }
+        msg = {"type": "room.end"}
         self.send_json(msg)
         self.close()
 


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

방에 다양한 기능 추가

## 🧑‍💻 PR 세부 내용

### 구현 기능 1: 방 자동 삭제

- 방장이 방을 나가면 해당 방을 삭제
- 방 내부에 있던 참가자들에게는 `type: room.end` 메시지를 보내고 웹소켓 연결을 끊음
  - 해당 메시지를 받으면 '방이 종료되었습니다 ' 등의 메시지를 띄우고 홈으로 가게 하면 될 듯

### 구현 기능 2: 유저의 현재 상태 변경

- 유저가 `type: room.change.state` 메시지를 보내면 해당 유저의 상태를 변경
- 유저가 상태를 변경하면 방에 접속 중인 모두에게 갱신된 방 정보를 다시 보냄

### 구현 기능 3: 방 정보 변경

- 유저가 `type: room.change.info` 메시지를 보내면 방 정보를 수정
  - 난이도, 총점, 공 색깔, 패들 색깔만 수정 가능
- 메시지 형식
```json
{
  "type": "room.change.info",
  "data": {
	  "level":2,
    "total_score":10,
    "color":{
      "paddle":"#5AD7FF",
      "ball":"#FFD164"
    },
  }
}
```
- 현재는 방장이 아니더라도 해당 메시지를 전송하면 방의 상태를 바꿀 수 있는 취약점이 존재
  - 이후에 해당 메시지를 보낸 유저가 방장인지 검사하여 방 수정 여부 결정하는 로직 추가 예정

### 기타 수정 사항

- 같은 유저인지 판단하는 코드 리팩토링
  - 기존에는 `room_user._nickname == user.nickname`으로 요청을 보낸 유저와 방 안에 있는 유저를 구분하고 있었음 -> protect 변수를 외부에서 참조하는 문제
  - RoomUser가 같은 유저인지 판단하도록 `is_same()` 메서드 추가
  - ex) `room_user.is_same(user)`

- 유저가 방을 나갈 경우 예외가 발생하던 오류 수정
  - 원인: 이미 방을 나간 유저에게 room_info를 전달하려고 하다가 발생
    - room_info 내부에는 my_info라는 정보를 제공하는데, 이미 나간 유저의 정보가 없어 예외가 발생함
  - 해결: try-except 문을 사용하여 해당 예외 무시
    - 유저를 channel layers에서 나가게 한 뒤 메시지를 보내는 등 여러 방법을 고려했지만, 깔끔한 해결책이 없었음
    - 해당 예외를 잡는 방식으로 우선 해결

## 📸 스크린샷

###  방 자동 삭제

https://github.com/authenticity-house/ft_transcendence/assets/43935708/afc348f4-7da9-4cc0-bf2b-c442e29afce0

## 📚 관련 이슈

- close: #170 
