### PR TITLE
[Hotfix] 친구 요청 전송 시 friend_pk를 int로 보냈을 경우, 중복 요청 예외 처리

### DIFF
--- a/BE/users/views.py
+++ b/BE/users/views.py
@@ -142,7 +142,11 @@ class FriendAPIView(APIView):
 
     def post(self, request):
         user_pk: int = request.user.pk
-        friend_pk: int = get_friend_pk(request.data.get("friend_pk"))
+        friend_pk: int = (
+            request.data.get("friend_pk")
+            if isinstance(request.data.get("friend_pk"), int)
+            else get_friend_pk(str(request.data.get("friend_pk")))
+        )
 
         if user_pk == friend_pk:
             raise ParseError(detail="You cannot add yourself as a friend")

--- a/BE/users/views.py
+++ b/BE/users/views.py
@@ -20,6 +20,14 @@ from users.serializers import UserProfileSerializer
 from users.oauth import get_access_token, get_user_data, get_or_create_user
 
 
+class SelfFriendException(APIException):
+    status_code = status.HTTP_400_BAD_REQUEST
+    _custom_detail = {"code": "FRIEND_ERROR_0", "detail": "You cannot add yourself as a friend"}
+
+    def __init__(self, **kwargs):
+        super().__init__(detail=self._custom_detail)
+
+
 class AlreadyFriendException(APIException):
     status_code = status.HTTP_400_BAD_REQUEST
     _custom_detail = {"code": "FRIEND_ERROR_1", "detail": "Already friends."}
@@ -157,7 +165,7 @@ class FriendAPIView(APIView):
         )
 
         if user_pk == friend_pk:
-            raise ParseError(detail="You cannot add yourself as a friend")
+            raise SelfFriendException()
 
         try:
             user_profile = User.objects.get(pk=user_pk)
@@ -228,7 +236,7 @@ class SentFriendRequestDetailAPIView(APIView):
         user_pk: int = request.user.pk
 
         if user_pk == friend_pk:
-            raise ParseError(detail="You cannot add yourself as a friend")
+            raise SelfFriendException()
 
         friendship = Friendship.objects.filter(
             Q(from_user_id=user_pk, to_user_id=friend_pk)
@@ -250,7 +258,7 @@ class ReceivedFriendRequestDetailAPIView(APIView):
         user_pk: int = request.user.pk
 
         if user_pk == friend_pk:
-            raise ParseError(detail="You cannot add yourself as a friend")
+            raise SelfFriendException()
 
         try:
             from_to_friendship = Friendship.objects.get(from_user_id=user_pk, to_user_id=friend_pk)
@@ -266,7 +274,7 @@ class ReceivedFriendRequestDetailAPIView(APIView):
         user_pk: int = request.user.pk
 
         if user_pk == friend_pk:
-            raise ParseError(detail="You cannot add yourself as a friend")
+            raise SelfFriendException()
 
         friendship = Friendship.objects.filter(
             Q(from_user_id=user_pk, to_user_id=friend_pk)

--- a/BE/users/views.py
+++ b/BE/users/views.py
@@ -173,9 +173,14 @@ class FriendAPIView(APIView):
             if are_they_friend(from_user_to_friend, from_friend_to_user):
                 raise AlreadyFriendException()
 
-            if from_user_to_friend.are_we_friend is False:
-                from_user_to_friend.are_we_friend = True
-                from_user_to_friend.save()
+            if from_user_to_friend.are_we_friend is True:
+                return Response(
+                    {"code": "FRIEND_ERROR_2", "detail": "Friend request already sent."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            from_user_to_friend.are_we_friend = True
+            from_user_to_friend.save()
 
             return Response(
                 {"detail": "success"},

--- a/BE/users/views.py
+++ b/BE/users/views.py
@@ -36,12 +36,21 @@ class AlreadyFriendException(APIException):
         super().__init__(detail=self._custom_detail)
 
 
+class InvalidQueryParams(APIException):
+    status_code = 400
+
+    def __init__(self, key_str=""):
+        super().__init__(
+            detail={"code": "PARSE_ERROR", "detail": f"Query Params key should be {key_str}."}
+        )
+
+
 def get_friend_pk(friend_pk_str: str) -> int:
     if friend_pk_str is None:
-        raise ParseError(detail="friend_pk is empty")
+        raise ParseError(detail={"code": "PARSE_ERROR", "detail": "friend_pk is empty"})
 
     if not friend_pk_str.isdigit():
-        raise ParseError(detail="friend_pk can only be int type")
+        raise ParseError(detail={"code": "PARSE_ERROR", "detail": "friend_pk can only be int type"})
 
     return int(friend_pk_str)
 
@@ -53,7 +62,7 @@ def get_query_param(request, key):
 
     value = query_params[key]
     if value == "":
-        raise ParseError(detail=f"{key} value is empty")
+        raise ParseError(detail={"code": "PARSE_ERROR", "detail": f"{key} value is empty"})
 
     return value
 

--- a/BE/users/views.py
+++ b/BE/users/views.py
@@ -297,13 +297,6 @@ class ReceivedFriendRequestDetailAPIView(APIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class InvalidQueryParams(APIException):
-    status_code = 400
-
-    def __init__(self, key_str=""):
-        super().__init__(detail=f"Query Params key should be {key_str}.")
-
-
 class CheckDuplicateAPIView(APIView):
     allowed_keys = ["email", "nickname", "username"]
 


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

- 친구 요청 전송 시 friend_pk를 int로 보냈을 경우 예외 처리
- 이미 친구일 때 요청 전송 시 예외 처리

## 🧑‍💻 PR 세부 내용

### 친구 요청 전송 시 friend_pk를 int로 보냈을 경우 예외 처리
- body에 포함된 friend_pk가 str이라고 가정하고 코드를 작성했더니 int의 경우 isdigit 함수가 존재하지 않아 500 예외 발생
- 받아온 데이터가 int 형이라면 그대로 사용하도록 코드 수정

### 친구 요청 전송 시 예외 처리
400 Bad Request 발생 시 구분을 위해 에러 응답 전송 시 `code` 값 지정
**이는 친구 요청 전송 시 400 예외에서만 구분하기 위해 추가해두어 다른 예외 상태코드에는 없음**

- 본인에게 친구 요청 전송 → `FRIEND_ERROR_0`
- 이미 친구일 때 친구 요청 전송 → `FRIEND_ERROR_1`
- 친구 요청을 보낸 상태에서 친구 요청 전송 → `FRIEND_ERROR_2`
- 파싱 예외 발생 → `PARSE_ERROR`

## 📸 스크린샷

<img width="547" alt="Screen Shot 2024-04-30 at 5 29 42 PM" src="https://github.com/authenticity-house/ft_transcendence/assets/44529556/2e31e7ce-94e0-4e47-abbf-086eab3205ea">


## 📚 관련 이슈

- #179
