### PR TITLE
[Feat] 친구 목록, 보낸 요청, 받은 요청 API 연결

### DIFF
--- a/FE/src/components/MyFriendRequestNode.js
+++ b/FE/src/components/MyFriendRequestNode.js
@@ -5,22 +5,31 @@ class MyFriendRequestNode {
 		this.data = data;
 	}
 
-	template() {
+	template(pk) {
 		return html`
 			<div class="my-friend-request-node-container">
 				<span class="display-light28">${this.data.nickname}</span>
 				<div class="my-friend-request-node-button-container">
 					${this.data.sent
 						? html`
-								<button class="my-friend-request-node-cancel">
+								<button
+									id="my-friend-request-cancel-${pk}"
+									class="my-friend-request-node-cancel"
+								>
 									<img src="image/x-square.svg" alt="cancel" />
 								</button>
 							`
 						: html`
-								<button class="my-friend-request-node-accept">
+								<button
+									id="my-friend-request-accept-${pk}"
+									class="my-friend-request-node-accept"
+								>
 									<img src="image/check-square.svg" alt="accept" />
 								</button>
-								<button class="my-friend-request-node-reject">
+								<button
+									id="my-friend-request-reject-${pk}"
+									class="my-friend-request-node-reject"
+								>
 									<img src="image/x-square.svg" alt="reject" />
 								</button>
 							`}

--- a/FE/src/components/modal/profile_modal/FriendInfoContent.js
+++ b/FE/src/components/modal/profile_modal/FriendInfoContent.js
@@ -105,21 +105,19 @@ class FriendInfoContent {
 				.then((res) => {
 					if (res.detail === 'success') {
 						alert('친구 추가 요청을 보냈습니다.');
-					} else throw new Error(res.code);
-				})
-				.catch((code) => {
-					if (code === 'FRIEND_ERROR_0') {
+					} else if (res.code === 'FRIEND_ERROR_0') {
 						alert('자기 자신을 친구로 추가할 수 없습니다.');
-					} else if (code === 'FRIEND_ERROR_1') {
+					} else if (res.code === 'FRIEND_ERROR_1') {
 						alert('이미 친구인 사용자입니다.');
-					} else if (code === 'FRIEND_ERROR_2') {
+					} else if (res.code === 'FRIEND_ERROR_2') {
 						alert('이미 친구 요청을 보낸 사용자입니다.');
-					} else if (code === 'PARSE_ERROR') {
+					} else if (res.code === 'PARSE_ERROR') {
 						alert('잘못된 요청입니다.');
 					} else {
 						alert('친구 추가 요청을 보내는데 실패했습니다.');
 					}
-				});
+				})
+				.catch((err) => console.log(err));
 		});
 	}
 }

--- a/FE/src/components/modal/profile_modal/FriendInfoContent.js
+++ b/FE/src/components/modal/profile_modal/FriendInfoContent.js
@@ -98,15 +98,18 @@ class FriendInfoContent {
 					'X-CSRFToken': getCookie('csrftoken')
 				},
 				body: JSON.stringify({
-					friend_pk: data.pk
+					friend_pk: String(data.pk)
 				})
 			})
 				.then((res) => {
-					console.log(res);
 					return res.json();
 				})
 				.then((res) => {
-					console.log(res);
+					if (res.detail === 'success') {
+						alert('친구 추가 요청을 보냈습니다.');
+					} else {
+						alert('친구 추가 요청을 보내지 못했습니다.');
+					}
 				});
 		});
 	}

--- a/FE/src/components/modal/profile_modal/FriendInfoContent.js
+++ b/FE/src/components/modal/profile_modal/FriendInfoContent.js
@@ -47,7 +47,6 @@ class FriendInfoContent {
 			'.friend-info-content-name'
 		);
 
-		console.log('data: ', data);
 		if (data.profile_url !== '/profile/default.png') {
 			friendInfoContentImage.innerHTML = `
 				<img

--- a/FE/src/components/modal/profile_modal/FriendInfoContent.js
+++ b/FE/src/components/modal/profile_modal/FriendInfoContent.js
@@ -98,17 +98,26 @@ class FriendInfoContent {
 					'X-CSRFToken': getCookie('csrftoken')
 				},
 				body: JSON.stringify({
-					friend_pk: String(data.pk)
+					friend_pk: data.pk
 				})
 			})
-				.then((res) => {
-					return res.json();
-				})
+				.then((res) => res.json())
 				.then((res) => {
 					if (res.detail === 'success') {
 						alert('친구 추가 요청을 보냈습니다.');
+					} else throw new Error(res.code);
+				})
+				.catch((code) => {
+					if (code === 'FRIEND_ERROR_0') {
+						alert('자기 자신을 친구로 추가할 수 없습니다.');
+					} else if (code === 'FRIEND_ERROR_1') {
+						alert('이미 친구인 사용자입니다.');
+					} else if (code === 'FRIEND_ERROR_2') {
+						alert('이미 친구 요청을 보낸 사용자입니다.');
+					} else if (code === 'PARSE_ERROR') {
+						alert('잘못된 요청입니다.');
 					} else {
-						alert('친구 추가 요청을 보내지 못했습니다.');
+						alert('친구 추가 요청을 보내는데 실패했습니다.');
 					}
 				});
 		});

--- a/FE/src/components/modal/profile_modal/GetContent.js
+++ b/FE/src/components/modal/profile_modal/GetContent.js
@@ -202,67 +202,11 @@ export function getContent(id, userPk) {
 		myRecordContent.addEventListeners();
 	} else if (id === 'user-search') {
 		// user-search 탭을 클릭했을 때 유저 검색을 렌더링
-		// userSearchContent.addEventListeners();
 	} else if (id === 'my-friend') {
 		// my-friend 탭을 클릭했을 때 친구 목록을 렌더링
-		// mock-data
-		const data = {
-			friends: [
-				{
-					profile_url: 'image/default-profile.png',
-					nickname: 'jeongrol'
-				},
-				{
-					profile_url: 'image/default-profile.png',
-					nickname: 'wonyang'
-				},
-				{
-					profile_url: 'image/default-profile.png',
-					nickname: 'jihylim'
-				},
-				{
-					profile_url: 'image/default-profile.png',
-					nickname: 'jeongmin'
-				},
-				{
-					profile_url: 'image/default-profile.png',
-					nickname: 'joyoo'
-				}
-			],
-			friendRequestsSent: [
-				'jeongrol',
-				'wonyang',
-				'jeongrol',
-				'wonyang',
-				'jeongrol',
-				'wonyang',
-				'jeongrol',
-				'wonyang',
-				'jeongrol',
-				'wonyang',
-				'jeongrol',
-				'wonyang',
-				'jeongrol',
-				'wonyang',
-				'jeongrol',
-				'wonyang',
-				'jeongrol',
-				'wonyang',
-				'jeongrol',
-				'wonyang',
-				'jeongrol',
-				'wonyang',
-				'jeongrol',
-				'wonyang',
-				'jeongrol',
-				'wonyang',
-				'jihylim'
-			],
-			friendRequestsReceived: ['jeongmin', 'joyoo']
-		};
-
-		myFriendContent.mount(data);
-		myFriendContent.addEventListeners();
+		myFriendContent.fetchFriends();
+		myFriendContent.fetchFriendRequestsSent();
+		myFriendContent.fetchFriendRequestsReceived();
 	} else if (id === 'stats') {
 		const data = {
 			ratingChange: [

--- a/FE/src/components/modal/profile_modal/MyFriendContent.js
+++ b/FE/src/components/modal/profile_modal/MyFriendContent.js
@@ -1,5 +1,8 @@
+import apiEndpoints from '../../../constants/apiConfig.js';
+import { getCookie } from '../../../utils/getCookie.js';
 import MyFriendRequestNode from '../../MyFriendRequestNode.js';
 import UserNode from '../../UserNode.js';
+import { profileModal } from './ProfileModal.js';
 
 const html = String.raw;
 
@@ -72,7 +75,218 @@ class MyFriendContent {
 		myFriendRequestReceived.innerHTML = myFriendRequestsReceived;
 	}
 
-	addEventListeners() {}
+	mountFriends(data) {
+		let myFriends = '';
+
+		for (let i = 0; i < data.length; i += 1) {
+			const myFriendNode = new UserNode(data[i]);
+			myFriends += `
+				<button id="friend-profile-button-${data[i].pk}" class="user-node-button" data-bs-target="#friend-profile-modal" data-bs-toggle="modal">
+			`;
+			myFriends += myFriendNode.template();
+			myFriends += '</button>';
+		}
+
+		const myFriend = document.querySelector('.my-friend-row');
+		myFriend.innerHTML = myFriends;
+	}
+
+	mountFriendRequestsSent(data) {
+		let myFriendRequestsSent = '';
+
+		for (let i = 0; i < data.length; i += 1) {
+			const myFriendRequestSentNode = new MyFriendRequestNode({
+				nickname: data[i].nickname,
+				sent: true
+			});
+			myFriendRequestsSent += myFriendRequestSentNode.template(data[i].pk);
+		}
+
+		const myFriendRequestSent = document.querySelector(
+			'.my-friend-request-sent'
+		);
+		myFriendRequestSent.innerHTML = myFriendRequestsSent;
+	}
+
+	mountFriendRequestsReceived(data) {
+		let myFriendRequestsReceived = '';
+
+		for (let i = 0; i < data.length; i += 1) {
+			const myFriendRequestReceivedNode = new MyFriendRequestNode({
+				nickname: data[i].nickname,
+				sent: false
+			});
+			myFriendRequestsReceived += myFriendRequestReceivedNode.template(
+				data[i].pk
+			);
+		}
+
+		const myFriendRequestReceived = document.querySelector(
+			'.my-friend-request-received'
+		);
+		myFriendRequestReceived.innerHTML = myFriendRequestsReceived;
+	}
+
+	addFriendsEventListeners() {
+		const myFriendNodes = document.querySelectorAll('.user-node-button');
+
+		myFriendNodes.forEach((myFriendNode) => {
+			myFriendNode.addEventListener('click', () => {
+				const userPk = myFriendNode.id.split('-')[3];
+				profileModal.openFriendModal(userPk);
+			});
+		});
+	}
+
+	addFriendRequestsSentEventListeners() {
+		const myFriendRequestSentNodes = document.querySelectorAll(
+			'.my-friend-request-node-cancel'
+		);
+
+		// 친구 요청 취소
+		myFriendRequestSentNodes.forEach((myFriendRequestSentNode) => {
+			myFriendRequestSentNode.addEventListener('click', () => {
+				const userPk = myFriendRequestSentNode.id.split('-')[4];
+				fetch(`${apiEndpoints.MY_FRIEND_REQUEST_SENT_URL}${userPk}/`, {
+					method: 'DELETE',
+					headers: {
+						'Content-Type': 'application/json',
+						'X-CSRFToken': getCookie('csrftoken')
+					}
+				})
+					.then((res) => {
+						if (res.status !== 204)
+							throw new Error('친구 요청 취소에 실패했습니다.');
+					})
+					.then(() => {
+						// 친구 요청 보낸 목록 다시 불러오기
+						this.fetchFriendRequestsSent();
+					})
+					.catch((error) => {
+						alert(error);
+					});
+			});
+		});
+	}
+
+	addFriendRequestsReceivedEventListeners() {
+		const myFriendRequestReceivedAcceptNodes = document.querySelectorAll(
+			'.my-friend-request-node-accept'
+		);
+		const myFriendRequestReceivedRejectNodes = document.querySelectorAll(
+			'.my-friend-request-node-reject'
+		);
+
+		// 친구 요청 수락
+		myFriendRequestReceivedAcceptNodes.forEach(
+			(myFriendRequestReceivedAcceptNode) => {
+				myFriendRequestReceivedAcceptNode.addEventListener('click', () => {
+					const userPk = myFriendRequestReceivedAcceptNode.id.split('-')[4];
+					fetch(`${apiEndpoints.MY_FRIEND_REQUEST_RECEIVED_URL}${userPk}/`, {
+						method: 'POST',
+						headers: {
+							'Content-Type': 'application/json',
+							'X-CSRFToken': getCookie('csrftoken')
+						}
+					})
+						.then((res) => {
+							if (res.status !== 204)
+								throw new Error('친구 요청 수락에 실패했습니다.');
+						})
+						.then(() => {
+							// 친구 요청 받은 목록 다시 불러오기
+							this.fetchFriendRequestsReceived();
+							// 친구 목록 다시 불러오기
+							this.fetchFriends();
+						})
+						.catch((error) => {
+							alert(error);
+						});
+				});
+			}
+		);
+
+		// 친구 요청 거절
+		myFriendRequestReceivedRejectNodes.forEach(
+			(myFriendRequestReceivedRejectNode) => {
+				myFriendRequestReceivedRejectNode.addEventListener('click', () => {
+					const userPk = myFriendRequestReceivedRejectNode.id.split('-')[4];
+					fetch(`${apiEndpoints.MY_FRIEND_REQUEST_RECEIVED_URL}${userPk}/`, {
+						method: 'DELETE',
+						headers: {
+							'Content-Type': 'application/json',
+							'X-CSRFToken': getCookie('csrftoken')
+						}
+					})
+						.then((res) => {
+							if (res.status !== 204)
+								throw new Error('친구 요청 거절에 실패했습니다.');
+						})
+						.then(() => {
+							// 친구 요청 받은 목록 다시 불러오기
+							this.fetchFriendRequestsReceived();
+						})
+						.catch((error) => {
+							alert(error);
+						});
+				});
+			}
+		);
+	}
+
+	fetchFriends() {
+		fetch(apiEndpoints.MY_FRIEND_URL, {
+			method: 'GET',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-CSRFToken': getCookie('csrftoken')
+			},
+			mode: 'same-origin'
+		}).then((res) => {
+			if (res.status === 200) {
+				res.json().then((data) => {
+					this.mountFriends(data);
+					this.addFriendsEventListeners();
+				});
+			}
+		});
+	}
+
+	fetchFriendRequestsSent() {
+		fetch(apiEndpoints.MY_FRIEND_REQUEST_SENT_URL, {
+			method: 'GET',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-CSRFToken': getCookie('csrftoken')
+			},
+			mode: 'same-origin'
+		}).then((res) => {
+			if (res.status === 200) {
+				res.json().then((data) => {
+					this.mountFriendRequestsSent(data);
+					this.addFriendRequestsSentEventListeners();
+				});
+			}
+		});
+	}
+
+	fetchFriendRequestsReceived() {
+		fetch(apiEndpoints.MY_FRIEND_REQUEST_RECEIVED_URL, {
+			method: 'GET',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-CSRFToken': getCookie('csrftoken')
+			},
+			mode: 'same-origin'
+		}).then((res) => {
+			if (res.status === 200) {
+				res.json().then((data) => {
+					this.mountFriendRequestsReceived(data);
+					this.addFriendRequestsReceivedEventListeners();
+				});
+			}
+		});
+	}
 }
 
 export const myFriendContent = new MyFriendContent();

--- a/FE/src/components/modal/profile_modal/MyFriendContent.js
+++ b/FE/src/components/modal/profile_modal/MyFriendContent.js
@@ -30,51 +30,6 @@ class MyFriendContent {
 		`;
 	}
 
-	mount(data) {
-		this.data = data;
-
-		let myFriends = '';
-		let myFriendRequestsSent = '';
-		let myFriendRequestsReceived = '';
-
-		for (let i = 0; i < data.friends.length; i += 1) {
-			const myFriendNode = new UserNode(data.friends[i]);
-			myFriends += `
-				<button class="user-node-button" data-bs-target="#friend-profile-modal" data-bs-toggle="modal">
-			`;
-			myFriends += myFriendNode.template();
-			myFriends += '</button>';
-		}
-
-		for (let i = 0; i < data.friendRequestsSent.length; i += 1) {
-			const myFriendRequestSentNode = new MyFriendRequestNode({
-				nickname: data.friendRequestsSent[i],
-				sent: true
-			});
-			myFriendRequestsSent += myFriendRequestSentNode.template();
-		}
-
-		for (let i = 0; i < data.friendRequestsReceived.length; i += 1) {
-			const myFriendRequestReceivedNode = new MyFriendRequestNode({
-				nickname: data.friendRequestsReceived[i],
-				sent: false
-			});
-			myFriendRequestsReceived += myFriendRequestReceivedNode.template();
-		}
-
-		const myFriend = document.querySelector('.my-friend-row');
-		const myFriendRequestSent = document.querySelector(
-			'.my-friend-request-sent'
-		);
-		const myFriendRequestReceived = document.querySelector(
-			'.my-friend-request-received'
-		);
-
-		myFriend.innerHTML = myFriends;
-		myFriendRequestSent.innerHTML = myFriendRequestsSent;
-		myFriendRequestReceived.innerHTML = myFriendRequestsReceived;
-	}
-
 	mountFriends(data) {
 		let myFriends = '';
 
@@ -155,8 +110,11 @@ class MyFriendContent {
 					}
 				})
 					.then((res) => {
-						if (res.status !== 204)
+						if (res.status !== 204) {
+							this.fetchFriendRequestsSent();
+							this.fetchFriends();
 							throw new Error('친구 요청 취소에 실패했습니다.');
+						}
 					})
 					.then(() => {
 						// 친구 요청 보낸 목록 다시 불러오기
@@ -190,8 +148,11 @@ class MyFriendContent {
 						}
 					})
 						.then((res) => {
-							if (res.status !== 204)
+							if (res.status !== 204) {
+								this.fetchFriendRequestsReceived();
+								this.fetchFriends();
 								throw new Error('친구 요청 수락에 실패했습니다.');
+							}
 						})
 						.then(() => {
 							// 친구 요청 받은 목록 다시 불러오기
@@ -219,8 +180,11 @@ class MyFriendContent {
 						}
 					})
 						.then((res) => {
-							if (res.status !== 204)
+							if (res.status !== 204) {
+								this.fetchFriendRequestsReceived();
+								this.fetchFriends();
 								throw new Error('친구 요청 거절에 실패했습니다.');
+							}
 						})
 						.then(() => {
 							// 친구 요청 받은 목록 다시 불러오기
@@ -248,6 +212,10 @@ class MyFriendContent {
 					this.mountFriends(data);
 					this.addFriendsEventListeners();
 				});
+			} else if (res.status === 403) {
+				alert('로그인이 필요합니다.');
+			} else if (res.status === 404) {
+				alert('친구가 없습니다.');
 			}
 		});
 	}
@@ -266,6 +234,8 @@ class MyFriendContent {
 					this.mountFriendRequestsSent(data);
 					this.addFriendRequestsSentEventListeners();
 				});
+			} else if (res.status === 403) {
+				alert('로그인이 필요합니다.');
 			}
 		});
 	}
@@ -284,6 +254,8 @@ class MyFriendContent {
 					this.mountFriendRequestsReceived(data);
 					this.addFriendRequestsReceivedEventListeners();
 				});
+			} else if (res.status === 403) {
+				alert('로그인이 필요합니다.');
 			}
 		});
 	}

--- a/FE/src/constants/apiConfig.js
+++ b/FE/src/constants/apiConfig.js
@@ -20,7 +20,9 @@ function getApiEndpoints() {
 		MY_INFO_URL: `${USERS_URL}user/`,
 		SEARCH_USER_URL: `${USERS_URL}search/?prefix=`,
 		FRIEND_PROFILE_URL: `${USERS_URL}detail/`,
-		MY_FRIEND_URL: `${USERS_URL}friends/`
+		MY_FRIEND_URL: `${USERS_URL}friends/`,
+		MY_FRIEND_REQUEST_SENT_URL: `${USERS_URL}friends/sent/`,
+		MY_FRIEND_REQUEST_RECEIVED_URL: `${USERS_URL}friends/received/`
 	};
 }
 


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

친구 목록, 보낸 요청, 받은 요청 API 연결

## 🧑‍💻 PR 세부 내용

- 친구 목록, 보낸 요청, 받은 요청 API 연결
  - 친구 목록에서 친구 클릭 시 해당 정보 받아와서 모달로 연결
  - 보낸 요청 삭제 시 삭제 반영
  - 받은 요청 수락 시 친구 목록에 바로 업데이트
  - 받은 요청 거절 시 삭제
  - 처리된 건에 대한 비정상적 요청에 대해 "~에 실패했습니다."와 같은 문구로 실패 알림.
    - 204의 경우 no content이고, 400의 경우 데이터가 전달되는 형태라 따로 처리하는 것은 시간을 잡아먹는 행위라고 판단

## 📸 스크린샷

1. 친구 요청

![pong 친구 요청](https://github.com/authenticity-house/ft_transcendence/assets/49023654/a2e38641-b6e9-4f3a-85be-d76706045d2d)

2. 친구 수락

![pong 친구 수락](https://github.com/authenticity-house/ft_transcendence/assets/49023654/53fb916b-132e-4a49-86bb-0333b16c3db5)


4. 친구 거절

![pong 친구 거절](https://github.com/authenticity-house/ft_transcendence/assets/49023654/10a5eb19-c2ea-4e41-8b39-3f97617d3887)


5. 친구 요청 삭제

![pong 친구 요청 삭제](https://github.com/authenticity-house/ft_transcendence/assets/49023654/1a8f48bb-9f6f-4f0f-b3fa-eb1fb5b89b43)


## 📚 관련 이슈

#178 
