### PR TITLE
[Fix] 게임 중 score 관련 정보 서버에서 받아오도록 변경

### DIFF
--- a/FE/src/constants/constants.js
+++ b/FE/src/constants/constants.js
@@ -20,6 +20,12 @@ export const SubType = {
 };
 Object.freeze(SubType);
 
+export const GameMessages = {
+	READY: 'ready animation',
+	WIN: 'winner animation'
+};
+Object.freeze(GameMessages);
+
 export const registrationMessages = {
 	DEFAULT_ERROR: '회원가입에 실패했습니다.<br />다시 시도해주세요.',
 	PASSWORD_SIMILAR_TO_USERNAME:

--- a/FE/src/constants/constants.js
+++ b/FE/src/constants/constants.js
@@ -20,12 +20,6 @@ export const SubType = {
 };
 Object.freeze(SubType);
 
-export const Winner = {
-	PLAYER_1: 1,
-	PLAYER_2: 2
-};
-Object.freeze(Winner);
-
 export const registrationMessages = {
 	DEFAULT_ERROR: '회원가입에 실패했습니다.<br />다시 시도해주세요.',
 	PASSWORD_SIMILAR_TO_USERNAME:

--- a/FE/src/game/MessageManager.js
+++ b/FE/src/game/MessageManager.js
@@ -8,7 +8,7 @@ import GamePage from './GamePage.js';
 
 import { GameMessages as msg } from './Gamemessages.js';
 
-import { MessageType, SubType } from '../constants/constants.js';
+import { MessageType, SubType, GameMessages } from '../constants/constants.js';
 
 export class MessageManager {
 	constructor(websocket) {
@@ -258,10 +258,10 @@ export class MessageManager {
 			case SubType.MATCH_RUN:
 				// 로딩 중 지우기
 				// 수신한 매치 데이터로 rendering
-				if (message.message === 'ready animation') {
+				if (message.message === GameMessages.READY) {
 					this.frame += 1;
 					this.updateCameraPosition();
-				} else if (message.message === 'winner animation')
+				} else if (message.message === GameMessages.WIN)
 					this.displayWinner(message.data.score);
 				this.renderThreeJs(message.data);
 				break;

--- a/FE/src/game/MessageManager.js
+++ b/FE/src/game/MessageManager.js
@@ -133,7 +133,6 @@ export class MessageManager {
 	}
 
 	displayWinner(score) {
-		console.log('점수', score, score.player1, score.player2);
 		const winner = score.player1 > score.player2;
 		const winnerPosition = winner ? -4 : 4;
 		const targetPaddle = winner

--- a/FE/src/pages/online/rooms/waitingRoom/WaitingRoomPage.js
+++ b/FE/src/pages/online/rooms/waitingRoom/WaitingRoomPage.js
@@ -8,7 +8,6 @@ import ButtonBackArrow from '../../../../components/ButtonBackArrow.js';
 import { RoomWebsocket } from '../roomManager.js';
 import { roomModal } from '../roomModal.js';
 import ModifyGameSetting from './ModifyGameSetting.js';
-import { Gamewebsocket } from '../../../../game/Gamewebsocket.js';
 
 const html = String.raw;
 
@@ -55,7 +54,6 @@ class WaitingRoomPage {
 
 		try {
 			this.msg = await this.roomWsManager.receiveMessages(this.render);
-			console.log(this.msg);
 
 			this.updateReadyButton(this.msg);
 			this.addModifyEventListener();
@@ -112,7 +110,6 @@ class WaitingRoomPage {
 	addModifyEventListener() {
 		const roomInfoContainer = document.getElementById('roomInfoElement');
 		roomInfoContainer.addEventListener('click', (event) => {
-			console.log('클릭됨');
 			const modifyButton = event.target.closest('.room-info-modify-button');
 
 			if (modifyButton) {


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

게임 중 score 관련 정보 서버에서 받아오도록 변경

## 🧑‍💻 PR 세부 내용

1. 온라인 게임 종료 후 winner 애니메이션 추가되지 않는 오류 발생
2. 로컬 게임 진행 시 서버에서 받아온 정보가 아닌 기존 로컬이 가지고 있던 score 정보를 사용하고 있던 문제
3. 서버에서 보낸 메시지의 message를 판단하여 애니메이션 함수 실행

- ready animation
  ```
  {
      "type": "game",
      "subtype": "match_run",
      "message": "ready animation",
      "data": {
             ...
      }
  }
  ```

- winner animation
  - 서버에서 보낸 score을 비교하여 winner 결정 
  ```
  {
      "type": "game",
      "subtype": "match_run",
      "message": "winner animation",
      "data": {
          ...
          "score": {
              "player1": 2,
              "player2": 5
          }
      }
  }
  ```

## 📸 스크린샷

  <img width="450" alt="image" src="https://github.com/authenticity-house/ft_transcendence/assets/74870834/e0fdf8a3-50b0-4072-a0a3-a7e498970705">

## 📚 관련 이슈

- close #197 
