### PR TITLE
[Feat] 유저 게임 통계 모달 데이터 조회 API 구현

### DIFF
--- a/BE/stats/serializers.py
+++ b/BE/stats/serializers.py
@@ -93,8 +93,8 @@ class MatchSerializer(serializers.ModelSerializer):
         player2_pk = validated_data["player2"].pk
 
         try:
-            player1_stat = UserStat.objects.get(user_id=player1_pk)
-            player2_stat = UserStat.objects.get(user_id=player2_pk)
+            player1_stat, _ = UserStat.objects.get_or_create(user_id=player1_pk)
+            player2_stat, _ = UserStat.objects.get_or_create(user_id=player2_pk)
         except ObjectDoesNotExist as exc:
             raise NotFound(
                 detail=f"UserStat does not exist: pk={player1_pk} or {player2_pk}"

--- a/BE/stats/urls.py
+++ b/BE/stats/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import MatchAPIView, MatchListAPIView, UserStatSummaryAPIView
+from .views import MatchAPIView, MatchListAPIView, UserStatSummaryAPIView, UserStatAPIView
 
 urlpatterns = [
     path("match/list/<int:user_pk>/", MatchListAPIView.as_view(), name="another_user_match_list"),
@@ -11,4 +11,5 @@ urlpatterns = [
         name="another_user_game_stat_summary",
     ),
     path("summary/", UserStatSummaryAPIView.as_view(), name="my_game_stat_summary"),
+    path("", UserStatAPIView.as_view(), name="my_game_stat"),
 ]

--- a/BE/users/views.py
+++ b/BE/users/views.py
@@ -416,6 +416,7 @@ class CheckLoginStatusAPIView(APIView):
             }
         )
 
+
 class UpdateUserView(RetrieveUpdateAPIView):
     authentication_classes = [SessionAuthentication]
     permission_classes = [IsAuthenticated]
@@ -446,6 +447,7 @@ class UpdateUserView(RetrieveUpdateAPIView):
                 {"detail": "The nickname is already in use."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+
 
 class SessionAPIView(APIView):
     def get(self, request, *args, **kwargs):

--- a/BE/websocket/game_server.py
+++ b/BE/websocket/game_server.py
@@ -5,5 +5,5 @@ def request_game_session(room_info):
     url = "http://game:8000/online/"
     data = {"info": room_info}
     headers = {"Content-Type": "application/json"}
-    response = requests.post(url, json=data, headers=headers).json()
+    response = requests.post(url, json=data, headers=headers, timeout=10).json()
     return response["url"]


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

유저 게임 통계 모달 데이터 조회 API 구현

## 🧑‍💻 PR 세부 내용
> 자세한 형식은 [API 문서](https://www.notion.so/a791451934ed4a2cb290c7cac497af76?pvs=4)를 확인해주세요

`GET /stats/`

- serializer에 사용할 PlayTimeField 구현
  - h, m, s 단위로 만들기 위해 새로 작성
  - days는 모두 hours 단위로 합쳐서 처리

- UserStatSerializer는 UserStatSummarySerializer를 상속받아 구현
  - 겹치는 데이터를 사용하기 위해 상속
  - 추가로 필요한 필드 선언

- graph 데이터 생성
  - 최근 진행한 12 경기 기준 (12경기보다 작게 진행했다면 그만큼만 반환)
  - `match_cnt`: 경기 횟수(12경기보다 작은지 확인 필요)
  - `rating_change`: 오른쪽으로 갈 수록 최근 매치 데이터(빈 배열일 수도 있음)
  - `attack_type`: 공격 성향 카운트 (`TYPE0`: 공격형 / `TYPE1`: 방어형 / `TYPE2`: 혼합형)

- UserStat 정보가 없는 경우 생성하도록 코드 수정

- request_game_session post 요청 timeout 10초로 적용 (pylint 경고 제거)

## 📸 스크린샷

<img width=500 src="https://github.com/authenticity-house/ft_transcendence/assets/44529556/2be8c30c-d34a-41c4-898a-866d9848c3c1">

<img width=500 src="https://github.com/authenticity-house/ft_transcendence/assets/44529556/39db81fb-52a7-484e-b435-4e1615cd7cdd">


## 📚 관련 이슈

- #122
