### PR TITLE
[Feat] 로컬 매치 기록 전송 API 구현 및 게임서버 반영

### DIFF
--- a/BE/stats/models.py
+++ b/BE/stats/models.py
@@ -66,6 +66,9 @@ class UserStat(models.Model):
         if "online_match_data" in kwargs:
             match_data = kwargs.pop("online_match_data")
             self.online_update_stat(match_data)
+        elif "local_match_data" in kwargs:
+            match_data = kwargs.pop("local_match_data")
+            self.local_play_time += match_data.get("play_time", timedelta(seconds=0))
 
         self.max_rating = max(self.rating, self.max_rating)
         super().save()

--- a/BE/stats/models.py
+++ b/BE/stats/models.py
@@ -50,7 +50,7 @@ class UserStat(models.Model):
     create_date = models.DateTimeField(auto_now_add=True)
     update_date = models.DateTimeField(auto_now=True)
 
-    def update_stat(self, match_data: dict):
+    def online_update_stat(self, match_data: dict):
         self.rating = match_data.get("rating", self.rating)
         self.online_play_time += match_data.get("play_time", timedelta(seconds=0))
         self.max_ball_speed = max(self.max_ball_speed, match_data.get("max_ball_speed", 0))
@@ -63,9 +63,9 @@ class UserStat(models.Model):
             self.losses_count += 1
 
     def save(self, *args, **kwargs):
-        if "match_data" in kwargs:
-            match_data = kwargs.pop("match_data")
-            self.update_stat(match_data)
+        if "online_match_data" in kwargs:
+            match_data = kwargs.pop("online_match_data")
+            self.online_update_stat(match_data)
 
         self.max_rating = max(self.rating, self.max_rating)
         super().save()

--- a/BE/stats/serializers.py
+++ b/BE/stats/serializers.py
@@ -116,7 +116,7 @@ class UserStatSummarySerializer(serializers.ModelSerializer):
         if obj.wins_count + obj.losses_count == 0:
             return 0
 
-        return round(obj.wins_count / (obj.wins_count + obj.losses_count), 2)
+        return round(obj.wins_count / (obj.wins_count + obj.losses_count) * 100, 2)
 
     class Meta:
         model = UserStat

--- a/BE/stats/serializers.py
+++ b/BE/stats/serializers.py
@@ -60,7 +60,7 @@ class MatchSerializer(serializers.ModelSerializer):
             "is_winner": winner_id == player_stat.user_id,
         }
 
-        player_stat.save(match_data=update_match_data)
+        player_stat.save(online_match_data=update_match_data)
 
     def get_additional_data(self, data: dict, player1_pk: int, player2_pk: int) -> dict:
         player1_data: dict = dict(data["player1"])

--- a/BE/stats/serializers.py
+++ b/BE/stats/serializers.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 
@@ -11,24 +9,13 @@ from rest_framework.relations import PrimaryKeyRelatedField
 from users.models import User
 from users.serializers import UserProfileSerializer
 from .models import Match, UserStat
+from .time_utils import parse_timedelta
 
 attack_type_mapping: dict = {
     0: "TYPE0",
     1: "TYPE1",
     2: "TYPE2",
 }
-
-
-def parse_timedelta(time_str):
-    parts = time_str.split(":")
-    if len(parts) == 3:
-        hours, minutes, seconds = map(int, parts)
-        return timedelta(hours=hours, minutes=minutes, seconds=seconds)
-    if len(parts) == 2:
-        hours, minutes = map(int, parts)
-        return timedelta(hours=hours, minutes=minutes)
-
-    return timedelta(seconds=0)
 
 
 class MatchListSerializer(serializers.ModelSerializer):

--- a/BE/stats/tests.py
+++ b/BE/stats/tests.py
@@ -1,3 +1,0 @@
-# from django.test import TestCase
-
-# Create your tests here.

--- a/BE/stats/time_utils.py
+++ b/BE/stats/time_utils.py
@@ -1,13 +1,18 @@
 from datetime import timedelta
 
+from rest_framework.exceptions import ParseError
+
 
 def parse_timedelta(time_str):
-    parts = time_str.split(":")
-    if len(parts) == 3:
-        hours, minutes, seconds = map(int, parts)
-        return timedelta(hours=hours, minutes=minutes, seconds=seconds)
-    if len(parts) == 2:
-        hours, minutes = map(int, parts)
-        return timedelta(hours=hours, minutes=minutes)
+    try:
+        parts = time_str.split(":")
+        if len(parts) == 3:
+            hours, minutes, seconds = map(int, parts)
+            return timedelta(hours=hours, minutes=minutes, seconds=seconds)
+        if len(parts) == 2:
+            hours, minutes = map(int, parts)
+            return timedelta(hours=hours, minutes=minutes)
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        raise ParseError(detail=str(e)) from e
 
-    return timedelta(seconds=0)
+    return None

--- a/BE/stats/time_utils.py
+++ b/BE/stats/time_utils.py
@@ -1,0 +1,13 @@
+from datetime import timedelta
+
+
+def parse_timedelta(time_str):
+    parts = time_str.split(":")
+    if len(parts) == 3:
+        hours, minutes, seconds = map(int, parts)
+        return timedelta(hours=hours, minutes=minutes, seconds=seconds)
+    if len(parts) == 2:
+        hours, minutes = map(int, parts)
+        return timedelta(hours=hours, minutes=minutes)
+
+    return timedelta(seconds=0)

--- a/BE/stats/urls.py
+++ b/BE/stats/urls.py
@@ -1,10 +1,17 @@
 from django.urls import path
-from .views import MatchAPIView, MatchListAPIView, UserStatSummaryAPIView, UserStatAPIView
+from .views import (
+    MatchAPIView,
+    LocalMatchAPIView,
+    MatchListAPIView,
+    UserStatSummaryAPIView,
+    UserStatAPIView,
+)
 
 urlpatterns = [
     path("match/list/<int:user_pk>/", MatchListAPIView.as_view(), name="another_user_match_list"),
     path("match/list/", MatchListAPIView.as_view(), name="my_match_list"),
-    path("match/online/", MatchAPIView.as_view(), name="match"),
+    path("match/online/", MatchAPIView.as_view(), name="online_match_data"),
+    path("match/local/", LocalMatchAPIView.as_view(), name="local_match_data"),
     path(
         "summary/<int:user_pk>/",
         UserStatSummaryAPIView.as_view(),

--- a/BE/users/views.py
+++ b/BE/users/views.py
@@ -1,6 +1,5 @@
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import HttpResponseRedirect
-from django.db.models import Q
 from django.contrib.sessions.models import Session
 from django.contrib.auth import get_user_model
 from django.db.models import Q

--- a/GAME/websocket/backend_api.py
+++ b/GAME/websocket/backend_api.py
@@ -11,10 +11,15 @@ async def fetch_nickname(session_id):
             return None  # 응답 상태 코드가 200이 아닌 경우
 
 
-async def send_match_result(data):
-    url = "http://backend:8000/stats/match/online/"
+async def send_match_result(data, mode="online"):
+    url = f"http://backend:8000/stats/match/{mode}/"
+    success_status_code = 204 if mode == "local" else 201
+
     async with aiohttp.ClientSession() as session:
         async with session.post(url, json=data) as response:
-            response_data = await response.json()
-            if response.status != 201:
-                print("Error: " + response_data)
+            if response.status != success_status_code:
+                try:
+                    response_data = await response.json()
+                    print(f"Error: {response_data}")
+                except aiohttp.ContentTypeError:
+                    print(f"Error: Received status code {response.status}")


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

- 로컬 매치 기록 전송 API 구현 및 게임서버 반영
- 승률 퍼센트에 맞춰서 반환 값 수정

## 🧑‍💻 PR 세부 내용

### 로컬 매치 기록 전송 API 구현

`POST /stats/match/local/`
- pk와 play_time을 받아 해당 유저에 로컬 플레이 타임 반영
- 204 No Content(반영), 400 Bad Reqeust (형식 오류), 404 Not Found (유저 정보를 찾을 수 없음)
- `time_utils.py`로 파일 분리

### 게임서버 반영

- 온라인과 마찬가지로 Consumer 내부 pk 저장
  - 세션키가 있는지 확인하고 없으면 하지 않음
- `send_match_result` 함수에 인자로 mode 추가
- 이에 해당하는 처리도 함께 추가

## 📸 스크린샷

### API 응답 결과

<img width="600" alt="image" src="https://github.com/authenticity-house/ft_transcendence/assets/44529556/7fa37901-883b-46b0-9164-f9032ef5ec43">

### 퍼센트 반영

<img width="400" alt="image" src="https://github.com/authenticity-house/ft_transcendence/assets/44529556/17ae3e17-e3b4-4462-8240-b994b487c466">


## 📚 관련 이슈

- close #122
