### PR TITLE
[Feat] 랜덤 매치메이킹 추가

### DIFF
--- a/GAME/session/session_manager.py
+++ b/GAME/session/session_manager.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta, abstractmethod
+import random
 
 from match.match_manager import MatchManager
 from match.player import Player
@@ -98,6 +99,7 @@ class TournamentManager(ASessionManager):
         self._bracket: Bracket = None
 
     def set_nickname(self, nicknames):
+        random.shuffle(nicknames)
         self._bracket: Bracket = Bracket(nicknames, len(nicknames))
 
     # 소켓에서 전송할 데이터 반환
@@ -165,6 +167,7 @@ class DuelManager(ASessionManager):
         self._nickname = data.get("nickname", ["player1", "player2"])
 
     def set_nickname(self, nicknames):
+        random.shuffle(nicknames)
         self._nickname = nicknames
 
     # 소켓에서 전송할 데이터 반환


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

토너먼트와 완라인 1대1에 랜덤 매치메이킹 추가

## 🧑‍💻 PR 세부 내용

- 기존에는 따로 매치메이킹이 없었음
- random.shuffle 함수를 사용하여 닉네임 순서를 섞음

## 📸 스크린샷

https://github.com/authenticity-house/ft_transcendence/assets/43935708/722be0c5-a2fa-4e44-934a-783eca989ad9

## 📚 관련 이슈

- close: #222 
