### PR TITLE
[Feat] 모달 - 통계 공격성향 UI 개선

### DIFF
--- a/FE/public/css/styles.css
+++ b/FE/public/css/styles.css
@@ -2621,11 +2621,35 @@ td {
 
 .attack-tendency-wrapper {
 	display: flex;
+	flex-direction: column;
 	align-items: center;
 	justify-content: center;
 	width: 100%;
 	height: 100%;
 	border: 0.1rem solid #fff;
+	gap: 1rem;
+}
+
+.attack-tendency-value-container {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	width: 100%;
+	height: 3rem;
+	gap: 2.5rem;
+}
+
+.attack-tendency-value-wrapper {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	gap: 1rem;
+}
+
+.color-border {
+	width: 0.8rem;
+	height: 0.8rem;
+	border: 0.4rem solid white;
 }
 
 /* HelpButton.js */

--- a/FE/src/components/ModalGraphStats.js
+++ b/FE/src/components/ModalGraphStats.js
@@ -90,7 +90,6 @@ function drawAttackTendency(type) {
 		{ title: '방어형', value: type.TYPE2, color: '#5ad7ff' }
 	];
 	const canvas = document.querySelector('.attack-tendency-canvas');
-	const fontSize = 16;
 
 	const ctx = canvas.getContext('2d');
 	let totalValue = 0;
@@ -115,13 +114,26 @@ function drawAttackTendency(type) {
 		startAngle += angle;
 		// 텍스트 그리기
 		if (slice.value !== 0) {
-			const textX = centerX + (radius / 2) * Math.cos(sliceMiddleAngle);
-			const textY = centerY + (radius / 2) * Math.sin(sliceMiddleAngle);
-			ctx.fillStyle = '#000';
-			ctx.font = `${fontSize}px GongGothicLight`;
-			ctx.textAlign = 'center';
-			ctx.textBaseline = 'middle';
-			ctx.fillText(slice.title, textX, textY);
+			// 파이차트 크기에 따른 fontSize
+			let fontSize;
+			if (slice.value / totalValue >= 1 / 3) {
+				fontSize = 16;
+			} else if (slice.value / totalValue >= 1 / 6) {
+				fontSize = 12;
+			} else if (slice.value / totalValue >= 1 / 12) {
+				fontSize = 8;
+			} else {
+				fontSize = 4;
+			}
+			if (slice.value !== 0) {
+				const textX = centerX + (radius / 2) * Math.cos(sliceMiddleAngle);
+				const textY = centerY + (radius / 2) * Math.sin(sliceMiddleAngle);
+				ctx.fillStyle = '#000';
+				ctx.font = `${fontSize}px GongGothicLight`;
+				ctx.textAlign = 'center';
+				ctx.textBaseline = 'middle';
+				ctx.fillText(slice.title, textX, textY);
+			}
 		}
 	});
 }

--- a/FE/src/components/ModalGraphStats.js
+++ b/FE/src/components/ModalGraphStats.js
@@ -116,13 +116,14 @@ function drawAttackTendency(type) {
 		if (slice.value !== 0) {
 			// 파이차트 크기에 따른 fontSize
 			let fontSize;
-			if (slice.value / totalValue >= 1 / 3) {
+			if (slice.value / totalValue >= 4 / 12) {
 				fontSize = 16;
-			} else if (slice.value / totalValue >= 1 / 6) {
+			} else if (slice.value / totalValue >= 3 / 12) {
 				fontSize = 12;
-			} else if (slice.value / totalValue >= 1 / 12) {
+			} else if (slice.value / totalValue >= 2 / 12) {
 				fontSize = 8;
 			} else {
+				// 1 / 12
 				fontSize = 4;
 			}
 			if (slice.value !== 0) {
@@ -135,6 +136,17 @@ function drawAttackTendency(type) {
 				ctx.fillText(slice.title, textX, textY);
 			}
 		}
+	});
+
+	// attack tendency text
+	const tendencyValueWrapper = document.querySelectorAll(
+		'.attack-tendency-value-wrapper'
+	);
+	tendencyValueWrapper.forEach((wrapper, index) => {
+		const divElement = wrapper.querySelector('div');
+		divElement.style.borderColor = attackTendency[index].color;
+		const spanElement = wrapper.querySelector('span');
+		spanElement.textContent = `${attackTendency[index].title}: ${attackTendency[index].value}`;
 	});
 }
 

--- a/FE/src/components/modal/profile_modal/StatsContent.js
+++ b/FE/src/components/modal/profile_modal/StatsContent.js
@@ -97,9 +97,23 @@ class StatsContent {
 						<div class="attack-tendency-wrapper">
 							<canvas
 								class="attack-tendency-canvas"
-								width="200"
-								height="200"
+								width="180"
+								height="180"
 							></canvas>
+							<div class="attack-tendency-value-container display-light14">
+								<div class="attack-tendency-value-wrapper">
+									<div class="color-border"></div>
+									<span></span>
+								</div>
+								<div class="attack-tendency-value-wrapper">
+									<div class="color-border"></div>
+									<span></span>
+								</div>
+								<div class="attack-tendency-value-wrapper">
+									<div class="color-border"></div>
+									<span></span>
+								</div>
+							</div>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 모달 - 통계 공격성향 UI 수정

## 🧑‍💻 PR 세부 내용
현재 파이 차트로 되어 있는 공격성향 UI의 부족한 점
- 파이 차트 안의 폰트 사이즈 16px 고정 되어 있어서, 특정 성향의 파이 차트가 작을 시 폰트가 오버플로우 되는 현상
   - 파이 차트의 각 비율 %의 따른 폰트 사이즈 px 동적으로 변환
- 몇 경기를 해서 파이 차트가 만들어졌는지 모르는 상황
   - 공격형, 혼합형, 방어형 횟수 텍스트 UI 추가
## 📸 스크린샷
### 게임 플레이 데이터 있을 시, 모달 통계 UI
<img width="600" alt="스크린샷 2024-05-05 오후 11 12 25" src="https://github.com/authenticity-house/ft_transcendence/assets/83465749/4894a70d-3582-47e8-a57c-ac0bf76b0e83">

<hr>

### 게임 플레이 데이터 없을 시, 모달 통계 UI
<img width="600" alt="스크린샷 2024-05-05 오후 11 09 57" src="https://github.com/authenticity-house/ft_transcendence/assets/83465749/89acab80-c718-4090-93e1-7da655f1a0a2">

## 📚 관련 이슈
#238