### PR TITLE
[Hotfix] 레이팅 변화율 그래프 겹치는 현상 해결

### DIFF
--- a/FE/src/components/ModalGraphStats.js
+++ b/FE/src/components/ModalGraphStats.js
@@ -67,6 +67,7 @@ function drawRatingChange(ratingChange) {
 	const toolTip = [];
 	if (maxNumber !== -1) {
 		const ctx = canvas.getContext('2d');
+		ctx.clearRect(0, 0, canvas.width, canvas.height);
 		for (let i = 0; i < ratingChange.length - 1; i += 1) {
 			const x1 = (i + 1) * widthDivide;
 			const x2 = (i + 2) * widthDivide;
@@ -92,6 +93,7 @@ function drawAttackTendency(type) {
 	const canvas = document.querySelector('.attack-tendency-canvas');
 
 	const ctx = canvas.getContext('2d');
+	ctx.clearRect(0, 0, canvas.width, canvas.height);
 	let totalValue = 0;
 	attackTendency.forEach((tendency) => {
 		totalValue += tendency.value;
@@ -124,7 +126,7 @@ function drawAttackTendency(type) {
 				fontSize = 8;
 			} else {
 				// 1 / 12
-				fontSize = 4;
+				fontSize = 7;
 			}
 			if (slice.value !== 0) {
 				const textX = centerX + (radius / 2) * Math.cos(sliceMiddleAngle);


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

레이팅 변화율 그래프 겹치는 현상 해결

## 🧑‍💻 PR 세부 내용

- 게임 종료 후 모달 - 통계로 가면, 기존에 그렸던 레이팅 변화율 그래프 + 게임 종료 후 갱신된 레이팅 변화율의 그래프 둘 다 있는 현상이 발생하는 것을 확인했습니다.
- canvas를 그리기 전에 canvas 안의 모든 것들을 clear해주는 함수를 추가하여 문제를 해결했습니다.
- (+) 추가로 공격 성향 그래프에서 특정 값이 1이면, fontSize를 4로 설정했더니 너무 작아보여서 7로 재설정했습니다.

## 📸 스크린샷
<img width="600" alt="image" src="https://github.com/authenticity-house/ft_transcendence/assets/83465749/be0ed7a4-b990-412f-9758-71d1cd12dcb9">

## 📚 관련 이슈
#242